### PR TITLE
Fix definition of MiB and GiB

### DIFF
--- a/units/unit_definitions.hpp
+++ b/units/unit_definitions.hpp
@@ -1203,8 +1203,8 @@ namespace precise {
         constexpr precise_unit GB(1000.0, MB);
 
         constexpr precise_unit KiB(1024.0, byte);
-        constexpr precise_unit MiB(1024.0, kB);
-        constexpr precise_unit GiB(1024.0, MB);
+        constexpr precise_unit MiB(1024.0, KiB);
+        constexpr precise_unit GiB(1024.0, MiB);
 
         constexpr precise_unit bit_s = log::logbase2;
         constexpr precise_unit shannon = bit_s;


### PR DESCRIPTION
MiB is 1024 KiB, not kB.  Not sure whether KiB (initial cap) versus kB (initial small) is intentional or whether KiB should be kiB?

GiB is 1024 MiB, not 1024 MB.