### PR TITLE
Unit data operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ These operations apply to units and precise_units
 -   also available are copy constructor and copy assignments
 -   `<unit> inv()`  generate a new unit containing the inverse unit  `m.inv()= 1/m`
 -   `<unit> pow(int power)` take a unit to power(NOTE: beware of limits on power representations of some units,  things will always wrap so it is defined but may not produce what you expect).  `power` can be negative.
--   `<unit> root(int power)`  non constexpr, take the root of a unit,  produces `error` unit if the root is not well defined.  power can be negative.
 -   `bool is_exactly_the_same(<unit>)` compare two units and check for exact equivalence in both the unit_data and the multiplier, NOTE: this uses double equality
 -   `bool has_same_base(<unit>|<unit_data>)`  check if the <unit_data> is the same
 -   `equivalent_non_counting(<unit>|<unit_data>)`   check if the units are equivalent ignoring the counting bases
@@ -204,6 +203,7 @@ These functions are not class methods but operate on units
 -   `bool is_valid(<unit>)`  check to make sure the unit is not an invalid unit( the multiplier is not a NaN) and the unit_data does not match the defined `invalid_unit`.
 -   ` bool is_temperature(<unit>)`  return true if the unit is a temperature unit such as `F` or `C` or one of the other temperature units.
 -   `bool is_normal(<unit>)` return true if the multiplier is a normal number, there is some defined unit base, not the identity unit, the multiplier is not negative, and not the default unit.  basically a simple way to check if you have some non-special unit that will behave more or less how you expect it to.  
+-   `<unit> root(<unit>, int power)`  non constexpr, take the root of a unit,  produces `error` unit if the root is not well defined.  power can be negative.
 -   `<unit> sqrt(<unit>)` convenience function for taking the sqrt of a unit.
 
 ### Measurement Operations
@@ -214,8 +214,6 @@ These functions are not class methods but operate on units
 -   `<unit> units() const`  get the units used as a basis for the measurement
 -   `<unit> as_unit() const`  take the measurement as is and convert it into a single unit.  For Examples say a was 10 m.    calling as_unit() on that measurement would produce a unit with a multiplier of 10 and a base of meters.
 -   `double value_as(<unit>)` get the value of a measurement as if it were measured in \<unit>
--   `<measurement> root(int)` generate a root of a measurement
--   `<measurement> pow(int)`  generate a measurement which is a specific power of another measurement
 
 #### Uncertain measurement methods
 Uncertatin measurements have a few additional functions to support the uncertainty calculations
@@ -239,10 +237,12 @@ Notes:  for regular measurements, `+` and `-` are not defined for doubles due to
 -   `<measurement>=<unit>/<double>`  
 -   `<measurement>=<double>/<unit>`  basically calling a number multiplied or divided by a <unit> produces a measurement,  `unit` produces a measurement and `precise_unit` produces a precise_measurement.  
 
-#### Measurement function
+#### Measurement functions
 
 -   `measurement measurement_cast(<measurement>)`  convert a precise_measurement into measurement
--   `fixed_measurement measurement_cast(fixed_precise_measurement)`  convert a fixed_precise_measurement into a fixed_measurement
+-   `fixed_measurement measurement_cast(<fixed*_measurement>)`  convert a fixed_precise_measurement or fixed_measurement into a fixed_measurement
+-   `<measurement> pow(<measurement>, int)`  generate a measurement which is a specific power of another measurement
+-   `<measurement> root(<measurement>, int)` generate a root of a measurement
 -   `<measurement>  sqrt(<measurement>)`  take the square root of a measurement of any kind,  the units need to have a valid root.  
 
 ### Available library functions
@@ -269,7 +269,7 @@ The units library has some support for commodities,  more might be added in the 
 -   `enableUserDefinedCommodities()`  enable the use of UserDefinedCommodities.  they are enabled by default.
 
 #### Other unit definitions
-These are all only partially implemented
+These are all only partially implemented, not recommended for use yet
 -   `precise_unit x12_unit(string)`  get a unit from an X12 string.
 -   `precise_unit dod_unit(string)`  get a unit from a DOD code string.
 -   `precise_unit r20_unit(string)`  get a unit from an r20 code string.

--- a/test/test_measurement.cpp
+++ b/test/test_measurement.cpp
@@ -141,10 +141,10 @@ TEST(measurement, powroot)
     EXPECT_EQ(v1.value(), 8.0);
     EXPECT_EQ(v1.units(), m.pow(3));
 
-    auto m2 = v1.root(3);
+    auto m2 = root(v1,3);
     EXPECT_TRUE(m2 == m1);
 
-    auto m0 = v1.root(0);
+    auto m0 = root(v1,0);
     EXPECT_EQ(m0.value(), 1.0);
     EXPECT_EQ(m0.units(), one);
 
@@ -347,7 +347,7 @@ TEST(fixedMeasurement, powroot)
     EXPECT_EQ(v1.value(), 8.0);
     EXPECT_EQ(v1.units(), m.pow(3));
 
-    auto m2 = v1.root(3);
+    auto m2 = root(v1,3);
     EXPECT_TRUE(m2 == m1);
 
     fixed_measurement m4(16.0, m.pow(2));
@@ -474,7 +474,7 @@ TEST(PreciseMeasurement, powroot)
     EXPECT_EQ(v1.value(), 8.0);
     EXPECT_EQ(v1.units(), precise::m.pow(3));
 
-    auto m2 = v1.root(3);
+    auto m2 = root(v1,3);
     EXPECT_TRUE(m2 == m1);
     precise_measurement m4(16.0, precise::m.pow(2));
     EXPECT_EQ(sqrt(m4), precise_measurement(4.0, precise::m));
@@ -521,7 +521,7 @@ TEST(fixedPreciseMeasurement, powroot)
     EXPECT_EQ(v1.value(), 8.0);
     EXPECT_EQ(v1.units(), precise::m.pow(3));
 
-    auto m2 = v1.root(3);
+    auto m2 = root(v1,3);
     EXPECT_TRUE(m2 == m1);
 
     fixed_precise_measurement m4(16.0, precise::m.pow(2));

--- a/test/test_measurement.cpp
+++ b/test/test_measurement.cpp
@@ -137,14 +137,14 @@ TEST(measurement, powroot)
 {
     measurement m1(2.0, m);
 
-    auto v1 = m1.pow(3);
+    auto v1 = pow(m1, 3);
     EXPECT_EQ(v1.value(), 8.0);
     EXPECT_EQ(v1.units(), m.pow(3));
 
-    auto m2 = root(v1,3);
+    auto m2 = root(v1, 3);
     EXPECT_TRUE(m2 == m1);
 
-    auto m0 = root(v1,0);
+    auto m0 = root(v1, 0);
     EXPECT_EQ(m0.value(), 1.0);
     EXPECT_EQ(m0.units(), one);
 
@@ -343,11 +343,11 @@ TEST(fixedMeasurement, powroot)
 {
     fixed_measurement m1(2.0, m);
 
-    auto v1 = m1.pow(3);
+    auto v1 = pow(m1, 3);
     EXPECT_EQ(v1.value(), 8.0);
     EXPECT_EQ(v1.units(), m.pow(3));
 
-    auto m2 = root(v1,3);
+    auto m2 = root(v1, 3);
     EXPECT_TRUE(m2 == m1);
 
     fixed_measurement m4(16.0, m.pow(2));
@@ -470,11 +470,11 @@ TEST(PreciseMeasurement, powroot)
 {
     precise_measurement m1(2.0, precise::m);
 
-    auto v1 = m1.pow(3);
+    auto v1 = pow(m1, 3);
     EXPECT_EQ(v1.value(), 8.0);
     EXPECT_EQ(v1.units(), precise::m.pow(3));
 
-    auto m2 = root(v1,3);
+    auto m2 = root(v1, 3);
     EXPECT_TRUE(m2 == m1);
     precise_measurement m4(16.0, precise::m.pow(2));
     EXPECT_EQ(sqrt(m4), precise_measurement(4.0, precise::m));
@@ -517,11 +517,11 @@ TEST(fixedPreciseMeasurement, powroot)
 {
     fixed_precise_measurement m1(2.0, precise::m);
 
-    auto v1 = m1.pow(3);
+    auto v1 = pow(m1, 3);
     EXPECT_EQ(v1.value(), 8.0);
     EXPECT_EQ(v1.units(), precise::m.pow(3));
 
-    auto m2 = root(v1,3);
+    auto m2 = root(v1, 3);
     EXPECT_TRUE(m2 == m1);
 
     fixed_precise_measurement m4(16.0, precise::m.pow(2));

--- a/test/test_uncertain_measurements.cpp
+++ b/test/test_uncertain_measurements.cpp
@@ -254,15 +254,15 @@ TEST(uncertainOps, pow1)
     uncertain_measurement y(3.0, 0.6, cm);
     uncertain_measurement Av(2.0, 0.2, cm.pow(2));
 
-    auto z = w * y.pow(2) / root(Av,2);
+    auto z = w * pow(y, 2) / root(Av, 2);
     EXPECT_NEAR(z.value(), 28.765, 0.0005);
     EXPECT_NEAR(z.uncertainty(), 13.07, 0.005);
 
-    auto z2 = w * y.pow(2) / sqrt(Av);
+    auto z2 = w * pow(y, 2) / sqrt(Av);
     EXPECT_NEAR(z2.value(), 28.765, 0.0005);
     EXPECT_NEAR(z2.uncertainty(), 13.07, 0.005);
 
-    auto zs = w.rss_product(y.pow(2)).rss_divide(root(Av,2));
+    auto zs = w.rss_product(pow(y, 2)).rss_divide(root(Av, 2));
     EXPECT_NEAR(zs.value(), 29, 0.5);
     EXPECT_NEAR(zs.uncertainty(), 12, 0.5);
 }
@@ -382,9 +382,9 @@ TEST(uncertainOps, testHeight)
     uncertain_measurement t(0.6, 0.06, s);
     measurement gc = 9.8 * m / s.pow(2);
 
-    auto y = v0 * t - 0.5 * gc * t.pow(2);
+    auto y = v0 * t - 0.5 * gc * pow(t, 2);
 
-    auto ys = v0.rss_product(t).rss_subtract(0.5 * gc * t.pow(2));
+    auto ys = v0.rss_product(t).rss_subtract(0.5 * gc * pow(t, 2));
 
     EXPECT_NEAR(y.uncertainty(), 0.712, 0.005);
     EXPECT_NEAR(y.value(), 0.636, 0.0005);

--- a/test/test_uncertain_measurements.cpp
+++ b/test/test_uncertain_measurements.cpp
@@ -254,7 +254,7 @@ TEST(uncertainOps, pow1)
     uncertain_measurement y(3.0, 0.6, cm);
     uncertain_measurement Av(2.0, 0.2, cm.pow(2));
 
-    auto z = w * y.pow(2) / Av.root(2);
+    auto z = w * y.pow(2) / root(Av,2);
     EXPECT_NEAR(z.value(), 28.765, 0.0005);
     EXPECT_NEAR(z.uncertainty(), 13.07, 0.005);
 
@@ -262,7 +262,7 @@ TEST(uncertainOps, pow1)
     EXPECT_NEAR(z2.value(), 28.765, 0.0005);
     EXPECT_NEAR(z2.uncertainty(), 13.07, 0.005);
 
-    auto zs = w.rss_product(y.pow(2)).rss_divide(Av.root(2));
+    auto zs = w.rss_product(y.pow(2)).rss_divide(root(Av,2));
     EXPECT_NEAR(zs.value(), 29, 0.5);
     EXPECT_NEAR(zs.uncertainty(), 12, 0.5);
 }

--- a/test/test_unit_ops.cpp
+++ b/test/test_unit_ops.cpp
@@ -63,39 +63,39 @@ TEST(unitOps, power)
 
 TEST(unitOps, root)
 {
-    EXPECT_EQ(m.root(0), one);
+    EXPECT_EQ(root(m,0), one);
     auto m1 = m.pow(1);
-    EXPECT_EQ(m, m1.root(1));
-    EXPECT_EQ(m.inv(), m1.root(-1));
+    EXPECT_EQ(m, root(m1,1));
+    EXPECT_EQ(m.inv(), root(m1,-1));
     auto m2 = m.pow(2);
-    EXPECT_EQ(m, m2.root(2));
+    EXPECT_EQ(m, root(m2,2));
 
     EXPECT_EQ(m, sqrt(m2));
 
     auto m4 = m.pow(4);
-    EXPECT_EQ(m * m, m4.root(2));
-    EXPECT_EQ(m, m4.root(4));
+    EXPECT_EQ(m * m, root(m4,2));
+    EXPECT_EQ(m, root(m4,4));
 
     auto ft1 = ft.pow(1);
-    EXPECT_EQ(ft, ft1.root(1));
-    EXPECT_EQ(ft.inv(), ft1.root(-1));
+    EXPECT_EQ(ft, root(ft1,1));
+    EXPECT_EQ(ft.inv(), root(ft1,-1));
 
     auto ft2 = ft.pow(2);
-    EXPECT_EQ(ft, ft2.root(2));
-    EXPECT_EQ(ft.inv(), ft2.root(-2));
+    EXPECT_EQ(ft, root(ft2,2));
+    EXPECT_EQ(ft.inv(), root(ft2,-2));
     auto ft3 = ft.pow(3);
-    EXPECT_EQ(ft, ft3.root(3));
-    EXPECT_EQ(ft.inv(), ft3.root(-3));
+    EXPECT_EQ(ft, root(ft3,3));
+    EXPECT_EQ(ft.inv(), root(ft3,-3));
     auto ft4 = ft.pow(4);
-    EXPECT_EQ(ft * ft, ft4.root(2));
-    EXPECT_EQ(ft, ft4.root(4));
-    EXPECT_EQ(ft.inv(), ft4.root(-4));
+    EXPECT_EQ(ft * ft, root(ft4,2));
+    EXPECT_EQ(ft, root(ft4,4));
+    EXPECT_EQ(ft.inv(), root(ft4,-4));
 
     auto ft5 = ft.pow(5);
-    EXPECT_EQ(ft, ft5.root(5));
-    EXPECT_EQ(ft.inv(), ft5.root(-5));
+    EXPECT_EQ(ft, root(ft5,5));
+    EXPECT_EQ(ft.inv(), root(ft5,-5));
 
-    EXPECT_EQ(unit(-4.5, m).root(2), error);
+    EXPECT_EQ(root(unit(-4.5, m),2), error);
 }
 
 TEST(unitOps, nan)
@@ -324,36 +324,36 @@ TEST(preciseUnitOps, Power)
 TEST(preciseUnitOps, root)
 {
     auto m1 = precise::m.pow(1);
-    EXPECT_EQ(precise::m, m1.root(1));
-    EXPECT_EQ(precise::m.inv(), m1.root(-1));
+    EXPECT_EQ(precise::m, root(m1,1));
+    EXPECT_EQ(precise::m.inv(), root(m1,-1));
     auto m2 = precise::m.pow(2);
-    EXPECT_EQ(precise::m, m2.root(2));
+    EXPECT_EQ(precise::m, root(m2,2));
     EXPECT_EQ(precise::m, sqrt(m2));
     auto m4 = precise::m.pow(4);
-    EXPECT_EQ(precise::m * precise::m, m4.root(2));
-    EXPECT_EQ(precise::m, m4.root(4));
+    EXPECT_EQ(precise::m * precise::m, root(m4,2));
+    EXPECT_EQ(precise::m, root(m4,4));
 
-    EXPECT_EQ(precise::ft.root(0), precise::one);
+    EXPECT_EQ(root(precise::ft,0), precise::one);
     auto ft1 = precise::ft.pow(1);
-    EXPECT_EQ(precise::ft, ft1.root(1));
-    EXPECT_EQ(precise::ft.inv(), ft1.root(-1));
+    EXPECT_EQ(precise::ft, root(ft1,1));
+    EXPECT_EQ(precise::ft.inv(), root(ft1,-1));
 
     auto ft2 = precise::ft.pow(2);
-    EXPECT_EQ(precise::ft, ft2.root(2));
-    EXPECT_EQ(precise::ft.inv(), ft2.root(-2));
+    EXPECT_EQ(precise::ft, root(ft2,2));
+    EXPECT_EQ(precise::ft.inv(), root(ft2,-2));
     auto ft3 = precise::ft.pow(3);
-    EXPECT_EQ(precise::ft, ft3.root(3));
-    EXPECT_EQ(precise::ft.inv(), ft3.root(-3));
+    EXPECT_EQ(precise::ft, root(ft3,3));
+    EXPECT_EQ(precise::ft.inv(), root(ft3,-3));
     auto ft4 = precise::ft.pow(4);
-    EXPECT_EQ(precise::ft * precise::ft, ft4.root(2));
-    EXPECT_EQ(precise::ft, ft4.root(4));
-    EXPECT_EQ(precise::ft.inv(), ft4.root(-4));
+    EXPECT_EQ(precise::ft * precise::ft, root(ft4,2));
+    EXPECT_EQ(precise::ft, root(ft4,4));
+    EXPECT_EQ(precise::ft.inv(), root(ft4,-4));
 
     auto ft5 = precise::ft.pow(5);
-    EXPECT_EQ(precise::ft, ft5.root(5));
-    EXPECT_EQ(precise::ft.inv(), ft5.root(-5));
+    EXPECT_EQ(precise::ft, root(ft5,5));
+    EXPECT_EQ(precise::ft.inv(), root(ft5,-5));
 
-    EXPECT_TRUE(is_error((precise_unit(-4.5, m).root(2))));
+    EXPECT_TRUE(is_error(root(precise_unit(-4.5, m),2)));
 }
 
 TEST(preciseUnitOps, nan)

--- a/test/test_unit_ops.cpp
+++ b/test/test_unit_ops.cpp
@@ -51,7 +51,7 @@ TEST(unitOps, power)
 {
     auto m2 = m.pow(2);
     EXPECT_EQ(m * m, m2);
-    auto m4 = m.pow(4);
+    auto m4 = pow(m, 4); //use the free function form
     EXPECT_EQ(m * m * m * m, m4);
     auto m4_b = m2.pow(2);
     EXPECT_EQ(m4_b, m * m * m * m);
@@ -63,39 +63,39 @@ TEST(unitOps, power)
 
 TEST(unitOps, root)
 {
-    EXPECT_EQ(root(m,0), one);
+    EXPECT_EQ(root(m, 0), one);
     auto m1 = m.pow(1);
-    EXPECT_EQ(m, root(m1,1));
-    EXPECT_EQ(m.inv(), root(m1,-1));
-    auto m2 = m.pow(2);
-    EXPECT_EQ(m, root(m2,2));
+    EXPECT_EQ(m, root(m1, 1));
+    EXPECT_EQ(m.inv(), root(m1, -1));
+    auto m2 = pow(m, 2);
+    EXPECT_EQ(m, root(m2, 2));
 
     EXPECT_EQ(m, sqrt(m2));
 
     auto m4 = m.pow(4);
-    EXPECT_EQ(m * m, root(m4,2));
-    EXPECT_EQ(m, root(m4,4));
+    EXPECT_EQ(m * m, root(m4, 2));
+    EXPECT_EQ(m, root(m4, 4));
 
     auto ft1 = ft.pow(1);
-    EXPECT_EQ(ft, root(ft1,1));
-    EXPECT_EQ(ft.inv(), root(ft1,-1));
+    EXPECT_EQ(ft, root(ft1, 1));
+    EXPECT_EQ(ft.inv(), root(ft1, -1));
 
     auto ft2 = ft.pow(2);
-    EXPECT_EQ(ft, root(ft2,2));
-    EXPECT_EQ(ft.inv(), root(ft2,-2));
+    EXPECT_EQ(ft, root(ft2, 2));
+    EXPECT_EQ(ft.inv(), root(ft2, -2));
     auto ft3 = ft.pow(3);
-    EXPECT_EQ(ft, root(ft3,3));
-    EXPECT_EQ(ft.inv(), root(ft3,-3));
+    EXPECT_EQ(ft, root(ft3, 3));
+    EXPECT_EQ(ft.inv(), root(ft3, -3));
     auto ft4 = ft.pow(4);
-    EXPECT_EQ(ft * ft, root(ft4,2));
-    EXPECT_EQ(ft, root(ft4,4));
-    EXPECT_EQ(ft.inv(), root(ft4,-4));
+    EXPECT_EQ(ft * ft, root(ft4, 2));
+    EXPECT_EQ(ft, root(ft4, 4));
+    EXPECT_EQ(ft.inv(), root(ft4, -4));
 
     auto ft5 = ft.pow(5);
-    EXPECT_EQ(ft, root(ft5,5));
-    EXPECT_EQ(ft.inv(), root(ft5,-5));
+    EXPECT_EQ(ft, root(ft5, 5));
+    EXPECT_EQ(ft.inv(), root(ft5, -5));
 
-    EXPECT_EQ(root(unit(-4.5, m),2), error);
+    EXPECT_EQ(root(unit(-4.5, m), 2), error);
 }
 
 TEST(unitOps, nan)
@@ -314,7 +314,7 @@ TEST(preciseUnitOps, Power)
 {
     auto m2 = precise::m.pow(2);
     EXPECT_EQ(precise::m * precise::m, m2);
-    auto m4 = m.pow(4);
+    auto m4 = pow(m, 4);
     EXPECT_EQ(precise::m * precise::m * precise::m * precise::m, m4);
     auto m4_b = m2.pow(2);
     EXPECT_EQ(m4_b, precise::m * precise::m * precise::m * precise::m);
@@ -324,36 +324,36 @@ TEST(preciseUnitOps, Power)
 TEST(preciseUnitOps, root)
 {
     auto m1 = precise::m.pow(1);
-    EXPECT_EQ(precise::m, root(m1,1));
-    EXPECT_EQ(precise::m.inv(), root(m1,-1));
-    auto m2 = precise::m.pow(2);
-    EXPECT_EQ(precise::m, root(m2,2));
+    EXPECT_EQ(precise::m, root(m1, 1));
+    EXPECT_EQ(precise::m.inv(), root(m1, -1));
+    auto m2 = pow(precise::m, 2); //use the alternate free function form
+    EXPECT_EQ(precise::m, root(m2, 2));
     EXPECT_EQ(precise::m, sqrt(m2));
     auto m4 = precise::m.pow(4);
-    EXPECT_EQ(precise::m * precise::m, root(m4,2));
-    EXPECT_EQ(precise::m, root(m4,4));
+    EXPECT_EQ(precise::m * precise::m, root(m4, 2));
+    EXPECT_EQ(precise::m, root(m4, 4));
 
-    EXPECT_EQ(root(precise::ft,0), precise::one);
+    EXPECT_EQ(root(precise::ft, 0), precise::one);
     auto ft1 = precise::ft.pow(1);
-    EXPECT_EQ(precise::ft, root(ft1,1));
-    EXPECT_EQ(precise::ft.inv(), root(ft1,-1));
+    EXPECT_EQ(precise::ft, root(ft1, 1));
+    EXPECT_EQ(precise::ft.inv(), root(ft1, -1));
 
     auto ft2 = precise::ft.pow(2);
-    EXPECT_EQ(precise::ft, root(ft2,2));
-    EXPECT_EQ(precise::ft.inv(), root(ft2,-2));
+    EXPECT_EQ(precise::ft, root(ft2, 2));
+    EXPECT_EQ(precise::ft.inv(), root(ft2, -2));
     auto ft3 = precise::ft.pow(3);
-    EXPECT_EQ(precise::ft, root(ft3,3));
-    EXPECT_EQ(precise::ft.inv(), root(ft3,-3));
+    EXPECT_EQ(precise::ft, root(ft3, 3));
+    EXPECT_EQ(precise::ft.inv(), root(ft3, -3));
     auto ft4 = precise::ft.pow(4);
-    EXPECT_EQ(precise::ft * precise::ft, root(ft4,2));
-    EXPECT_EQ(precise::ft, root(ft4,4));
-    EXPECT_EQ(precise::ft.inv(), root(ft4,-4));
+    EXPECT_EQ(precise::ft * precise::ft, root(ft4, 2));
+    EXPECT_EQ(precise::ft, root(ft4, 4));
+    EXPECT_EQ(precise::ft.inv(), root(ft4, -4));
 
     auto ft5 = precise::ft.pow(5);
-    EXPECT_EQ(precise::ft, root(ft5,5));
-    EXPECT_EQ(precise::ft.inv(), root(ft5,-5));
+    EXPECT_EQ(precise::ft, root(ft5, 5));
+    EXPECT_EQ(precise::ft.inv(), root(ft5, -5));
 
-    EXPECT_TRUE(is_error(root(precise_unit(-4.5, m),2)));
+    EXPECT_TRUE(is_error(root(precise_unit(-4.5, m), 2)));
 }
 
 TEST(preciseUnitOps, nan)

--- a/units/unit_definitions.hpp
+++ b/units/unit_definitions.hpp
@@ -1008,35 +1008,35 @@ namespace precise {
             switch (logtype) {
                 case 0:
                 case 10:
-                    return pow(10.0, val);
+                    return std::pow(10.0, val);
                 case 1:
-                    return exp(val / ((is_power_unit(UT)) ? 0.5 : 1.0));
+                    return std::exp(val / ((is_power_unit(UT)) ? 0.5 : 1.0));
                 case 2:
-                    return pow(10.0, val / ((is_power_unit(UT)) ? 1.0 : 2.0));
+                    return std::pow(10.0, val / ((is_power_unit(UT)) ? 1.0 : 2.0));
                 case 3:
-                    return pow(10.0, val / ((is_power_unit(UT)) ? 10.0 : 20.0));
+                    return std::pow(10.0, val / ((is_power_unit(UT)) ? 10.0 : 20.0));
                 case 4:
-                    return pow(10.0, -val);
+                    return std::pow(10.0, -val);
                 case 5:
-                    return pow(100.0, -val);
+                    return std::pow(100.0, -val);
                 case 6:
-                    return pow(1000.0, -val);
+                    return std::pow(1000.0, -val);
                 case 7:
-                    return pow(50000.0, -val);
+                    return std::pow(50000.0, -val);
                 case 8:
-                    return exp2(val);
+                    return std::exp2(val);
                 case 9:
-                    return exp(val);
+                    return std::exp(val);
                 case 11:
-                    return pow(10.0, val / 10.0);
+                    return std::pow(10.0, val / 10.0);
                 case 12:
-                    return pow(10.0, val / 2.0);
+                    return std::pow(10.0, val / 2.0);
                 case 13:
-                    return pow(10.0, val / 20.0);
+                    return std::pow(10.0, val / 20.0);
                 case 14:
-                    return pow(3.0, val);
+                    return std::pow(3.0, val);
                 case 15:
-                    return exp(val / 0.5);
+                    return std::exp(val / 0.5);
                 case 22: // saffir simpson hurricane wind scale
                 {
                     double out = -0.17613636364;
@@ -1055,13 +1055,13 @@ namespace precise {
                     return out;
                 }
                 case 24: // Fujita scale
-                    return 14.1 * pow(val + 2.0, 1.5);
+                    return 14.1 * std::pow(val + 2.0, 1.5);
                 case 27: // prism diopter
-                    return atan(val / 100.0);
+                    return std::atan(val / 100.0);
                 case 29: // moment magnitude scale
-                    return pow(10.0, (val + 10.7) * 1.5);
+                    return std::pow(10.0, (val + 10.7) * 1.5);
                 case 30:
-                    return pow(10.0, (val + 3.2) * 1.5);
+                    return std::pow(10.0, (val + 3.2) * 1.5);
                 default:
                     return val;
             }
@@ -1081,33 +1081,33 @@ namespace precise {
             switch (logtype) {
                 case 0:
                 case 10:
-                    return log10(val);
+                    return std::log10(val);
                 case 1:
                     return ((is_power_unit(UT)) ? 0.5 : 1.0) * (std::log)(val);
                 case 2:
-                    return ((is_power_unit(UT)) ? 1.0 : 2.0) * log10(val);
+                    return ((is_power_unit(UT)) ? 1.0 : 2.0) * std::log10(val);
                 case 3:
-                    return ((is_power_unit(UT)) ? 10.0 : 20.0) * log10(val);
+                    return ((is_power_unit(UT)) ? 10.0 : 20.0) * std::log10(val);
                 case 4:
-                    return -log10(val);
+                    return -std::log10(val);
                 case 5:
-                    return -log10(val) / 2.0;
+                    return -std::log10(val) / 2.0;
                 case 6:
-                    return -log10(val) / 3.0;
+                    return -std::log10(val) / 3.0;
                 case 7:
-                    return -log10(val) / log10(50000);
+                    return -std::log10(val) / std::log10(50000);
                 case 8:
                     return (std::log2)(val);
                 case 9:
                     return (std::log)(val);
                 case 11:
-                    return 10.0 * log10(val);
+                    return 10.0 * std::log10(val);
                 case 12:
-                    return 2.0 * log10(val);
+                    return 2.0 * std::log10(val);
                 case 13:
-                    return 20.0 * log10(val);
+                    return 20.0 * std::log10(val);
                 case 14:
-                    return log10(val) / log10(3);
+                    return std::log10(val) / std::log10(3);
                 case 15:
                     return 0.5 * (std::log)(val);
                 case 22: // saffir simpson hurricane scale from wind speed
@@ -1130,13 +1130,13 @@ namespace precise {
                     return out;
                 }
                 case 24: // fujita scale
-                    return pow(val / 14.1, 2.0 / 3.0) - 2.0;
+                    return std::pow(val / 14.1, 2.0 / 3.0) - 2.0;
                 case 27:
-                    return 100.0 * tan(val);
+                    return 100.0 * std::tan(val);
                 case 29: // moment magnitude scale
-                    return 2.0 / 3.0 * log10(val) - 10.7;
+                    return 2.0 / 3.0 * std::log10(val) - 10.7;
                 case 30: // energy magnitude scale
-                    return 2.0 / 3.0 * log10(val) - 3.2;
+                    return 2.0 / 3.0 * std::log10(val) - 3.2;
                 default:
                     return val;
             }

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -1150,7 +1150,7 @@ static double getNumberBlock(const std::string& ustring, size_t& index)
             double pval = getNumberBlock(ustring.substr(index + 1), nindex);
             if (!std::isnan(pval)) {
                 index += nindex + 1;
-                return pow(val, pval);
+                return std::pow(val, pval);
             }
             index = 0;
             return constants::invalid_conversion;

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -52,54 +52,54 @@ X numericalRoot(X value, int power)
     }
 }
 
-unit unit::root(int power) const
+unit root(unit un, int power)
 {
     if (power == 0) {
         return one;
     }
-    if (multiplier_ < 0.0f && power % 2 == 0) {
+    if (un.multiplier() < 0.0 && power % 2 == 0) {
         return error;
     }
-    return unit{base_units_.root(power), numericalRoot(multiplier_, power)};
+    return unit{un.base_units().root(power), numericalRoot(un.multiplier(), power)};
 }
 
-precise_unit precise_unit::root(int power) const
+precise_unit root(precise_unit un, int power)
 {
     if (power == 0) {
         return precise::one;
     }
-    if (multiplier_ < 0.0 && power % 2 == 0) {
+    if (un.multiplier() < 0.0 && power % 2 == 0) {
         return precise::invalid;
     }
-    return precise_unit{base_units_.root(power), numericalRoot(multiplier_, power)};
+    return precise_unit{un.base_units().root(power), numericalRoot(un.multiplier(), power)};
 }
 
-measurement measurement::root(int power) const
+measurement root(const measurement &meas, int power)
 {
-    return measurement(numericalRoot(value_, power), units_.root(power));
+    return measurement(numericalRoot(meas.value(), power), root(meas.units(),power));
 }
 
-fixed_measurement fixed_measurement::root(int power) const
+fixed_measurement root(const fixed_measurement &fm, int power)
 {
-    return fixed_measurement(numericalRoot(value_, power), units_.root(power));
+    return fixed_measurement(numericalRoot(fm.value(), power), root(fm.units(),power));
 }
 
-uncertain_measurement uncertain_measurement::root(int power) const
+uncertain_measurement root(const uncertain_measurement &um, int power)
 {
-    auto new_value = numericalRoot(value_, power);
+    auto new_value = numericalRoot(um.value(), power);
     auto new_tol =
-        new_value * uncertainty_ / (static_cast<float>((power >= 0) ? power : -power) * value_);
-    return uncertain_measurement(new_value, new_tol, units_.root(power));
+        new_value * um.uncertainty() / (static_cast<double>((power >= 0) ? power : -power) * um.value());
+    return uncertain_measurement(new_value, new_tol, root(um.units(),power));
 }
 
-precise_measurement precise_measurement::root(int power) const
+precise_measurement root(const precise_measurement &pm, int power)
 {
-    return precise_measurement(numericalRoot(value_, power), units_.root(power));
+    return precise_measurement(numericalRoot(pm.value(), power), root(pm.units(),power));
 }
 
-fixed_precise_measurement fixed_precise_measurement::root(int power) const
+fixed_precise_measurement root(const fixed_precise_measurement &fpm, int power)
 {
-    return fixed_precise_measurement(numericalRoot(value_, power), units_.root(power));
+    return fixed_precise_measurement(numericalRoot(fpm.value(), power), root(fpm.units(),power));
 }
 
 // sum the powers of a unit
@@ -733,7 +733,7 @@ static std::string to_string_internal(precise_unit un, uint32_t match_flags)
     /// Check for squared units
     if (!un.base_units().root(2).has_e_flag() && !un.base_units().has_i_flag() &&
         un.multiplier() > 0.0) {
-        auto squ = llunit.root(2);
+        auto squ = root(llunit,2);
         fnd = find_unit(squ);
         if (!fnd.empty()) {
             return fnd + "^2";
@@ -745,7 +745,7 @@ static std::string to_string_internal(precise_unit un, uint32_t match_flags)
     }
     /// Check for cubed units
     if (!un.base_units().root(3).has_e_flag() && !un.base_units().has_i_flag()) {
-        auto cub = llunit.root(3);
+        auto cub = root(llunit,3);
         fnd = find_unit(cub);
         if (!fnd.empty()) {
             return fnd + "^3";

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -74,32 +74,32 @@ precise_unit root(precise_unit un, int power)
     return precise_unit{un.base_units().root(power), numericalRoot(un.multiplier(), power)};
 }
 
-measurement root(const measurement &meas, int power)
+measurement root(const measurement& meas, int power)
 {
-    return measurement(numericalRoot(meas.value(), power), root(meas.units(),power));
+    return measurement(numericalRoot(meas.value(), power), root(meas.units(), power));
 }
 
-fixed_measurement root(const fixed_measurement &fm, int power)
+fixed_measurement root(const fixed_measurement& fm, int power)
 {
-    return fixed_measurement(numericalRoot(fm.value(), power), root(fm.units(),power));
+    return fixed_measurement(numericalRoot(fm.value(), power), root(fm.units(), power));
 }
 
-uncertain_measurement root(const uncertain_measurement &um, int power)
+uncertain_measurement root(const uncertain_measurement& um, int power)
 {
     auto new_value = numericalRoot(um.value(), power);
-    auto new_tol =
-        new_value * um.uncertainty() / (static_cast<double>((power >= 0) ? power : -power) * um.value());
-    return uncertain_measurement(new_value, new_tol, root(um.units(),power));
+    auto new_tol = new_value * um.uncertainty() /
+        (static_cast<double>((power >= 0) ? power : -power) * um.value());
+    return uncertain_measurement(new_value, new_tol, root(um.units(), power));
 }
 
-precise_measurement root(const precise_measurement &pm, int power)
+precise_measurement root(const precise_measurement& pm, int power)
 {
-    return precise_measurement(numericalRoot(pm.value(), power), root(pm.units(),power));
+    return precise_measurement(numericalRoot(pm.value(), power), root(pm.units(), power));
 }
 
-fixed_precise_measurement root(const fixed_precise_measurement &fpm, int power)
+fixed_precise_measurement root(const fixed_precise_measurement& fpm, int power)
 {
-    return fixed_precise_measurement(numericalRoot(fpm.value(), power), root(fpm.units(),power));
+    return fixed_precise_measurement(numericalRoot(fpm.value(), power), root(fpm.units(), power));
 }
 
 // sum the powers of a unit
@@ -733,7 +733,7 @@ static std::string to_string_internal(precise_unit un, uint32_t match_flags)
     /// Check for squared units
     if (!un.base_units().root(2).has_e_flag() && !un.base_units().has_i_flag() &&
         un.multiplier() > 0.0) {
-        auto squ = root(llunit,2);
+        auto squ = root(llunit, 2);
         fnd = find_unit(squ);
         if (!fnd.empty()) {
             return fnd + "^2";
@@ -745,7 +745,7 @@ static std::string to_string_internal(precise_unit un, uint32_t match_flags)
     }
     /// Check for cubed units
     if (!un.base_units().root(3).has_e_flag() && !un.base_units().has_i_flag()) {
-        auto cub = root(llunit,3);
+        auto cub = root(llunit, 3);
         fnd = find_unit(cub);
         if (!fnd.empty()) {
             return fnd + "^3";

--- a/units/units.hpp
+++ b/units/units.hpp
@@ -265,9 +265,9 @@ class measurement {
         return {val / meas.value_, meas.units_.inv()};
     }
 
-    constexpr measurement pow(int power) const
+    friend constexpr measurement pow(const measurement& meas, int power)
     {
-        return measurement{detail::power_const(value_, power), units_.pow(power)};
+        return measurement{detail::power_const(meas.value_, power), meas.units_.pow(power)};
     }
     /// Convert a unit to have a new base
     measurement convert_to(unit newUnits) const
@@ -428,9 +428,9 @@ class fixed_measurement {
     }
 
     /// take the measurement to some power
-    constexpr fixed_measurement pow(int power) const
+    constexpr friend fixed_measurement pow(const fixed_measurement& meas, int power)
     {
-        return fixed_measurement{detail::power_const(value_, power), units_.pow(power)};
+        return fixed_measurement{detail::power_const(meas.value_, power), meas.units_.pow(power)};
     }
     /// Convert a unit to have a new base
     fixed_measurement convert_to(unit newUnits) const
@@ -759,11 +759,13 @@ class uncertain_measurement {
     }
 
     /// take the measurement to some power
-    UNITS_CPP14_CONSTEXPR uncertain_measurement pow(int power) const
+    friend UNITS_CPP14_CONSTEXPR uncertain_measurement
+        pow(const uncertain_measurement& meas, int power)
     {
-        auto new_value = detail::power_const(value_, power);
-        auto new_tol = ((power >= 0) ? power : -power) * new_value * uncertainty_ / value_;
-        return uncertain_measurement{new_value, new_tol, units_.pow(power)};
+        auto new_value = detail::power_const(meas.value_, power);
+        auto new_tol =
+            ((power >= 0) ? power : -power) * new_value * meas.uncertainty_ / meas.value_;
+        return uncertain_measurement{new_value, new_tol, meas.units_.pow(power)};
     }
 
     /// Convert a unit to have a new base
@@ -974,9 +976,9 @@ class precise_measurement {
     }
 
     /// take the measurement to some power
-    constexpr precise_measurement pow(int power) const
+    constexpr friend precise_measurement pow(const precise_measurement& meas, int power)
     {
-        return precise_measurement{detail::power_const(value_, power), units_.pow(power)};
+        return precise_measurement{detail::power_const(meas.value_, power), meas.units_.pow(power)};
     }
 
     /// Convert a unit to have a new base
@@ -1182,9 +1184,10 @@ class fixed_precise_measurement {
     }
 
     /// take the measurement to some power
-    constexpr fixed_precise_measurement pow(int power) const
+    constexpr friend fixed_precise_measurement pow(const fixed_precise_measurement& meas, int power)
     {
-        return fixed_precise_measurement{detail::power_const(value_, power), units_.pow(power)};
+        return fixed_precise_measurement{detail::power_const(meas.value_, power),
+                                         meas.units_.pow(power)};
     }
 
     /// Convert a unit to have a new base
@@ -1300,19 +1303,19 @@ constexpr measurement measurement_cast(measurement measure)
 
 #ifndef UNITS_HEADER_ONLY
 
-measurement root(const measurement &meas, int power);
+measurement root(const measurement& meas, int power);
 
-fixed_measurement root(const fixed_measurement &fm, int power);
+fixed_measurement root(const fixed_measurement& fm, int power);
 
-uncertain_measurement root(const uncertain_measurement &um, int power);
+uncertain_measurement root(const uncertain_measurement& um, int power);
 
-precise_measurement root(const precise_measurement &pm, int power);
+precise_measurement root(const precise_measurement& pm, int power);
 
-fixed_precise_measurement root(const fixed_precise_measurement &fpm, int power);
+fixed_precise_measurement root(const fixed_precise_measurement& fpm, int power);
 
 inline measurement sqrt(const measurement& meas)
 {
-    return root(meas,2);
+    return root(meas, 2);
 }
 
 inline precise_measurement sqrt(const precise_measurement& meas)

--- a/units/units.hpp
+++ b/units/units.hpp
@@ -265,10 +265,6 @@ class measurement {
         return {val / meas.value_, meas.units_.inv()};
     }
 
-#ifndef UNITS_HEADER_ONLY
-    /// take the root of a unit to some power
-    measurement root(int power) const;
-#endif
     constexpr measurement pow(int power) const
     {
         return measurement{detail::power_const(value_, power), units_.pow(power)};
@@ -431,10 +427,6 @@ class fixed_measurement {
         return fixed_measurement(value_ - val, units_);
     }
 
-#ifndef UNITS_HEADER_ONLY
-    /// take the root of a measurement to some power
-    fixed_measurement root(int power) const;
-#endif
     /// take the measurement to some power
     constexpr fixed_measurement pow(int power) const
     {
@@ -765,10 +757,7 @@ class uncertain_measurement {
         float cval = static_cast<float>(other.value_as(units_));
         return uncertain_measurement(value_ - cval, uncertainty_, units_);
     }
-#ifndef UNITS_HEADER_ONLY
-    /// take the root of a measurement to some power
-    uncertain_measurement root(int power) const;
-#endif
+
     /// take the measurement to some power
     UNITS_CPP14_CONSTEXPR uncertain_measurement pow(int power) const
     {
@@ -984,10 +973,6 @@ class precise_measurement {
         return {value_ - other.value_as(units_), units_};
     }
 
-#ifndef UNITS_HEADER_ONLY
-    /// take the root of a measurement to some power
-    precise_measurement root(int power) const;
-#endif
     /// take the measurement to some power
     constexpr precise_measurement pow(int power) const
     {
@@ -1196,10 +1181,6 @@ class fixed_precise_measurement {
         return *this;
     }
 
-#ifndef UNITS_HEADER_ONLY
-    /// take the root of a measurement to some power
-    fixed_precise_measurement root(int power) const;
-#endif
     /// take the measurement to some power
     constexpr fixed_precise_measurement pow(int power) const
     {
@@ -1319,29 +1300,39 @@ constexpr measurement measurement_cast(measurement measure)
 
 #ifndef UNITS_HEADER_ONLY
 
+measurement root(const measurement &meas, int power);
+
+fixed_measurement root(const fixed_measurement &fm, int power);
+
+uncertain_measurement root(const uncertain_measurement &um, int power);
+
+precise_measurement root(const precise_measurement &pm, int power);
+
+fixed_precise_measurement root(const fixed_precise_measurement &fpm, int power);
+
 inline measurement sqrt(const measurement& meas)
 {
-    return meas.root(2);
+    return root(meas,2);
 }
 
 inline precise_measurement sqrt(const precise_measurement& meas)
 {
-    return meas.root(2);
+    return root(meas, 2);
 }
 
 inline fixed_measurement sqrt(const fixed_measurement& meas)
 {
-    return meas.root(2);
+    return root(meas, 2);
 }
 
 inline uncertain_measurement sqrt(const uncertain_measurement& meas)
 {
-    return meas.root(2);
+    return root(meas, 2);
 }
 
 inline fixed_precise_measurement sqrt(const fixed_precise_measurement& meas)
 {
-    return meas.root(2);
+    return root(meas, 2);
 }
 
 /** The unit conversion flag are some modifiers for the string conversion operations,

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -48,7 +48,7 @@ namespace detail {
         }
 
         // perform a multiply operation by adding the powers together
-        constexpr unit_data operator+(unit_data other) const
+        constexpr unit_data operator*(unit_data other) const
         {
             return {
                 meter_ + other.meter_,
@@ -70,7 +70,7 @@ namespace detail {
             };
         }
         /// Division equivalent operator
-        constexpr unit_data operator-(unit_data other) const
+        constexpr unit_data operator/(unit_data other) const
         {
             return {meter_ - other.meter_,
                     kilogram_ - other.kilogram_,
@@ -437,12 +437,12 @@ class unit {
     /// Unit multiplication
     constexpr unit operator*(unit other) const
     {
-        return {base_units_ + other.base_units_, multiplier() * other.multiplier()};
+        return {base_units_ * other.base_units_, multiplier() * other.multiplier()};
     }
     /// Division operator
     constexpr unit operator/(unit other) const
     {
-        return {base_units_ - other.base_units_, multiplier() / other.multiplier()};
+        return {base_units_ / other.base_units_, multiplier() / other.multiplier()};
     }
     /// Invert the unit (take 1/unit)
     constexpr unit inv() const { return {base_units_.inv(), 1.0 / multiplier()}; }
@@ -591,7 +591,7 @@ class precise_unit {
     /// Multiply with another unit
     constexpr precise_unit operator*(precise_unit other) const
     {
-        return {base_units_ + other.base_units_,
+        return {base_units_ * other.base_units_,
                 (commodity_ == 0) ?
                     other.commodity_ :
                     ((other.commodity_ == 0) ? commodity_ : commodity_ & other.commodity_),
@@ -600,12 +600,12 @@ class precise_unit {
     /// Multiplication operator with a lower precision unit
     constexpr precise_unit operator*(unit other) const
     {
-        return {base_units_ + other.base_units_, commodity_, multiplier() * other.multiplier()};
+        return {base_units_ * other.base_units_, commodity_, multiplier() * other.multiplier()};
     }
     /// Division operator
     constexpr precise_unit operator/(precise_unit other) const
     {
-        return {base_units_ - other.base_units_,
+        return {base_units_ / other.base_units_,
                 (commodity_ == 0) ?
                     ((other.commodity_ == 0) ? 0 : ~other.commodity_) :
                     ((other.commodity_ == 0) ? commodity_ : commodity_ & (~other.commodity_)),
@@ -614,7 +614,7 @@ class precise_unit {
     /// Divide by a less precise unit
     constexpr precise_unit operator/(unit other) const
     {
-        return {base_units_ - other.base_units_, commodity_, multiplier() / other.multiplier()};
+        return {base_units_ / other.base_units_, commodity_, multiplier() / other.multiplier()};
     }
     /// take a unit to a power
     constexpr precise_unit pow(int power) const

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -451,10 +451,6 @@ class unit {
     {
         return unit{base_units_.pow(power), detail::power_const(multiplier_, power)};
     }
-#ifndef UNITS_HEADER_ONLY
-    /// take the root of a unit to some power
-    unit root(int power) const;
-#endif
     /// Test for unit equivalence to within nominal numerical tolerance (6 decimal digits)
     bool operator==(unit other) const
     {
@@ -788,14 +784,20 @@ inline bool isinf(unit u)
 }
 
 #ifndef UNITS_HEADER_ONLY
+
+/// take the root of a unit to some power
+unit root(unit u, int power);
+
+precise_unit root(precise_unit u, int power);
+
 inline unit sqrt(unit u)
 {
-    return u.root(2);
+    return root(u,2);
 }
 
 inline precise_unit sqrt(precise_unit u)
 {
-    return u.root(2);
+    return root(u,2);
 }
 #endif
 

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -782,6 +782,25 @@ inline bool isinf(unit u)
 {
     return std::isinf(u.multiplier());
 }
+/** generate a unit which is an integer power of another
+@param u the unit to raise to a specific power
+@param power the integral power, can be positive or negative
+@return a new unit with the appropriate value
+*/
+inline constexpr unit pow(unit u, int power)
+{
+    return u.pow(power);
+}
+
+/** generate a precise unit which is an integer power of another
+@param u the precise unit to raise to a specific power
+@param power the integral power, can be positive or negative
+@return a new precise unit with the appropriate value
+*/
+inline constexpr precise_unit pow(precise_unit u, int power)
+{
+    return u.pow(power);
+}
 
 #ifndef UNITS_HEADER_ONLY
 
@@ -792,12 +811,12 @@ precise_unit root(precise_unit u, int power);
 
 inline unit sqrt(unit u)
 {
-    return root(u,2);
+    return root(u, 2);
 }
 
 inline precise_unit sqrt(precise_unit u)
 {
-    return root(u,2);
+    return root(u, 2);
 }
 #endif
 


### PR DESCRIPTION
Move \<measurement\> pow and root to free functions instead of members.  
adjust the readme.  
move unit root function to free function so the classes are the same under header only and non header only.  
adjust the test cases with the new function calls.  
add overloads of the units for pow as a free function.  I think it still works best to have the units pow function be a member function since it is actually used frequently.  root not as much.  
unit_base still has a root member since that does a lot of the low level calculations on root powers and wouldn't make sense as a non-member function