### PR TITLE
Uncertainty update

### DIFF
--- a/docs/user-guide/uncertain_measurements.rst
+++ b/docs/user-guide/uncertain_measurements.rst
@@ -1,3 +1,45 @@
 =======================
 Uncertain Measurements
 =======================
+
+The units library supports a class of measurements including an uncertainty measurement.
+
+For Example `3.0±0.2m`  would indicate a measurement of 3.0 meters with an uncertainty of 0.2 m.  
+
+All operations are supported 
+The propagation of uncertainty follow the root sum of squares methods outlined `Here<http://lectureonline.cl.msu.edu/~mmp/labs/error/e2.htm>`_.  
+There are methods available such as `simple_divide`, `simple_product`, `simple_sum` and `simple_subtract` that just sum the uncertainties.  The method in use in the regular operators assume that the mesurements used in the mathematical operation are independent.  A more thorough explanation can be found `Here<http://web.mit.edu/fluids-modules/www/exper_techniques/2.Propagation_of_Uncertaint.pdf>`_.
+
+
+The structure of an uncertain measurement consists of a float for the measurement value and a float for the uncertainty, and `unit` for the unit of the measurement.  
+
+Constructors
+----------------
+
+There are a number of different constructors for an uncertain measurement aimed at specify the uncertatinty and measurement in different ways.  
+
+-   `constexpr uncertain_measurement()`   default constructor with 0 values for the value and uncertainty and a one for the unit.  
+
+-   `constexpr uncertain_measurement(<float|double> val, <float|double> uncertainty, unit base)` : specify the parameters with values
+    
+-   `constexpr uncertain_measurement(<float|double> val, unit base)`:  Just specify the value and unit, assume 0.0 uncertainty.  
+
+-    `constexpr uncertain_measurement(measurement val, float uncertainty) noexcept` : construct from a measurement and uncertainty value
+   
+-   `uncertain_measurement(measurement val, measurement uncertainty) noexcept`:  construct from a measurement value and uncertainty measurement.  The uncertainty is converted to the same units as the value measurement.  
+      
+
+Additional operators
+----------------------
+
+Beyond the operations used in :ref:`Measurements`, there are some specific functions related to getting and setting the uncertainty.
+
+-   `uncertain_measurement& uncertainty(<double|float> newUncertainty)` :  Will set the uncertainty value as a numerical value 
+-   `uncertain_measurement& uncertainty(const measurement &newUncerrtainty)`: will set the uncertainty as a measurement in specific units.  
+-   `double uncertainty()`:  Will get the current numerical value of the uncertainty 
+-   `double uncertainty_as(units)`:  will get the value of the uncertainty in specific units.  
+-   `float uncertainty_f()`: will get the value of the uncertainty as a single precision floating point value 
+-   `constexpr measurement uncertainty_measurement()`:  will return a measurement containing the uncertainty.  
+-   `double fractional_uncertainty()`: will get the fractional uncertainty value. which is uncertainty/\|value\|.  
+
+

--- a/test/test_uncertain_measurements.cpp
+++ b/test/test_uncertain_measurements.cpp
@@ -102,7 +102,7 @@ TEST(uncertainOps, addsubtract)
     uncertain_measurement y(3.0, 0.6, cm);
     uncertain_measurement w(4.52, 0.02, cm);
 
-    auto z =  x.simple_add(y).simple_subtract(w);
+    auto z = x.simple_add(y).simple_subtract(w);
     EXPECT_NEAR(z.value(), 0.5, 0.05);
     EXPECT_NEAR(z.uncertainty(), 0.8, 0.05);
 
@@ -146,7 +146,7 @@ TEST(uncertainOps, mult)
     uncertain_measurement w(4.52, 0.02, cm);
     uncertain_measurement x(2.0, 0.2, cm);
 
-    auto zs=w.simple_product(x);
+    auto zs = w.simple_product(x);
     EXPECT_NEAR(zs.value(), 9.04, 0.005);
     EXPECT_NEAR(zs.uncertainty(), 0.944, 0.0005);
     EXPECT_EQ(zs.units(), cm.pow(2));
@@ -256,17 +256,16 @@ TEST(uncertainOps, pow1)
     uncertain_measurement Av(2.0, 0.2, cm.pow(2));
 
     auto z = w * pow(y, 2) / root(Av, 2);
-	EXPECT_NEAR(z.value(), 29, 0.5);
-	EXPECT_NEAR(z.uncertainty(), 12, 0.5);
-   
+    EXPECT_NEAR(z.value(), 29, 0.5);
+    EXPECT_NEAR(z.uncertainty(), 12, 0.5);
 
     auto z2 = w * pow(y, 2) / sqrt(Av);
-	EXPECT_NEAR(z2.value(), 29, 0.5);
-	EXPECT_NEAR(z2.uncertainty(), 12, 0.5);
+    EXPECT_NEAR(z2.value(), 29, 0.5);
+    EXPECT_NEAR(z2.uncertainty(), 12, 0.5);
 
     auto zs = w.simple_product(pow(y, 2)).simple_divide(root(Av, 2));
-	EXPECT_NEAR(zs.value(), 28.765, 0.0005);
-	EXPECT_NEAR(zs.uncertainty(), 13.07, 0.005);
+    EXPECT_NEAR(zs.value(), 28.765, 0.0005);
+    EXPECT_NEAR(zs.uncertainty(), 13.07, 0.005);
 }
 #endif
 
@@ -278,12 +277,11 @@ TEST(uncertainOps, example1)
     uncertain_measurement x2(14.4, 0.3, m);
 
     auto z = x2 - x1;
-	EXPECT_NEAR(z.value(), 5.1, 0.05);
-	EXPECT_NEAR(z.uncertainty(), 0.36, 0.005);
+    EXPECT_NEAR(z.value(), 5.1, 0.05);
+    EXPECT_NEAR(z.uncertainty(), 0.36, 0.005);
 
     auto zs = x2.simple_subtract(x1);
-	EXPECT_NEAR(zs.value(), 5.1, 0.05);
-    
+    EXPECT_NEAR(zs.value(), 5.1, 0.05);
 }
 
 TEST(uncertainOps, example2)
@@ -292,12 +290,11 @@ TEST(uncertainOps, example2)
     uncertain_measurement t(0.4, 0.1, s);
 
     auto v = x / t;
-	EXPECT_NEAR(v.value(), 12.75, 0.005);
-	EXPECT_NEAR(v.uncertainty(), 3.34, 0.005);
+    EXPECT_NEAR(v.value(), 12.75, 0.005);
+    EXPECT_NEAR(v.uncertainty(), 3.34, 0.005);
 
     auto vs = x.simple_divide(t);
-	EXPECT_NEAR(vs.value(), 12.75, 0.005);
-    
+    EXPECT_NEAR(vs.value(), 12.75, 0.005);
 }
 
 // next two examples from https://chem.libretexts.org/Bookshelves/Analytical_Chemistry/Supplemental_Modules_(Analytical_Chemistry)/Quantifying_Nature/Significant_Digits/Propagation_of_Error
@@ -307,7 +304,7 @@ TEST(uncertainOps, chemExample1)
     uncertain_measurement path(1.0, 0.1, cm);
     uncertain_measurement absorb(0.172807, 0.000008, one);
 
-    auto eps = absorb/(conc*path);
+    auto eps = absorb / (conc * path);
     EXPECT_NEAR(eps.value(), 0.013, 0.005);
     EXPECT_NEAR(eps.uncertainty(), 0.001, 0.0005);
 }
@@ -389,7 +386,7 @@ TEST(uncertainOps, testHeight)
 
     auto y = v0.simple_product(t).simple_subtract(0.5 * gc * pow(t, 2));
 
-    auto ys = v0*t-0.5 * gc * pow(t, 2);
+    auto ys = v0 * t - 0.5 * gc * pow(t, 2);
 
     EXPECT_NEAR(y.uncertainty(), 0.712, 0.005);
     EXPECT_NEAR(y.value(), 0.636, 0.0005);

--- a/test/test_uncertain_measurements.cpp
+++ b/test/test_uncertain_measurements.cpp
@@ -102,11 +102,11 @@ TEST(uncertainOps, addsubtract)
     uncertain_measurement y(3.0, 0.6, cm);
     uncertain_measurement w(4.52, 0.02, cm);
 
-    auto z = x + y - w;
+    auto z =  x.simple_add(y).simple_subtract(w);
     EXPECT_NEAR(z.value(), 0.5, 0.05);
     EXPECT_NEAR(z.uncertainty(), 0.8, 0.05);
 
-    auto zs = x.rss_add(y).rss_subtract(w);
+    auto zs = x + y - w;
     EXPECT_NEAR(zs.value(), 0.5F, 0.05);
     EXPECT_NEAR(zs.uncertainty(), 0.6, 0.05);
 }
@@ -146,15 +146,15 @@ TEST(uncertainOps, mult)
     uncertain_measurement w(4.52, 0.02, cm);
     uncertain_measurement x(2.0, 0.2, cm);
 
-    auto z = w * x;
-    EXPECT_NEAR(z.value(), 9.04, 0.005);
-    EXPECT_NEAR(z.uncertainty(), 0.944, 0.0005);
-    EXPECT_EQ(z.units(), cm.pow(2));
-
-    auto zs = w.rss_product(x);
+    auto zs=w.simple_product(x);
     EXPECT_NEAR(zs.value(), 9.04, 0.005);
-    EXPECT_NEAR(zs.uncertainty(), 0.905, 0.0005);
+    EXPECT_NEAR(zs.uncertainty(), 0.944, 0.0005);
     EXPECT_EQ(zs.units(), cm.pow(2));
+
+    auto z = w = w * x;
+    EXPECT_NEAR(z.value(), 9.04, 0.005);
+    EXPECT_NEAR(z.uncertainty(), 0.905, 0.0005);
+    EXPECT_EQ(z.units(), cm.pow(2));
 
     auto z2 = x * cm;
     EXPECT_FLOAT_EQ(z2.value(), 2.0F);
@@ -256,16 +256,17 @@ TEST(uncertainOps, pow1)
     uncertain_measurement Av(2.0, 0.2, cm.pow(2));
 
     auto z = w * pow(y, 2) / root(Av, 2);
-    EXPECT_NEAR(z.value(), 28.765, 0.0005);
-    EXPECT_NEAR(z.uncertainty(), 13.07, 0.005);
+	EXPECT_NEAR(z.value(), 29, 0.5);
+	EXPECT_NEAR(z.uncertainty(), 12, 0.5);
+   
 
     auto z2 = w * pow(y, 2) / sqrt(Av);
-    EXPECT_NEAR(z2.value(), 28.765, 0.0005);
-    EXPECT_NEAR(z2.uncertainty(), 13.07, 0.005);
+	EXPECT_NEAR(z2.value(), 29, 0.5);
+	EXPECT_NEAR(z2.uncertainty(), 12, 0.5);
 
-    auto zs = w.rss_product(pow(y, 2)).rss_divide(root(Av, 2));
-    EXPECT_NEAR(zs.value(), 29, 0.5);
-    EXPECT_NEAR(zs.uncertainty(), 12, 0.5);
+    auto zs = w.simple_product(pow(y, 2)).simple_divide(root(Av, 2));
+	EXPECT_NEAR(zs.value(), 28.765, 0.0005);
+	EXPECT_NEAR(zs.uncertainty(), 13.07, 0.005);
 }
 #endif
 
@@ -277,11 +278,12 @@ TEST(uncertainOps, example1)
     uncertain_measurement x2(14.4, 0.3, m);
 
     auto z = x2 - x1;
-    EXPECT_NEAR(z.value(), 5.1, 0.05);
+	EXPECT_NEAR(z.value(), 5.1, 0.05);
+	EXPECT_NEAR(z.uncertainty(), 0.36, 0.005);
 
-    auto zs = x2.rss_subtract(x1);
-    EXPECT_NEAR(zs.value(), 5.1, 0.05);
-    EXPECT_NEAR(zs.uncertainty(), 0.36, 0.005);
+    auto zs = x2.simple_subtract(x1);
+	EXPECT_NEAR(zs.value(), 5.1, 0.05);
+    
 }
 
 TEST(uncertainOps, example2)
@@ -290,11 +292,12 @@ TEST(uncertainOps, example2)
     uncertain_measurement t(0.4, 0.1, s);
 
     auto v = x / t;
-    EXPECT_NEAR(v.value(), 12.75, 0.005);
+	EXPECT_NEAR(v.value(), 12.75, 0.005);
+	EXPECT_NEAR(v.uncertainty(), 3.34, 0.005);
 
-    auto vs = x.rss_divide(t);
-    EXPECT_NEAR(vs.value(), 12.75, 0.005);
-    EXPECT_NEAR(vs.uncertainty(), 3.34, 0.005);
+    auto vs = x.simple_divide(t);
+	EXPECT_NEAR(vs.value(), 12.75, 0.005);
+    
 }
 
 // next two examples from https://chem.libretexts.org/Bookshelves/Analytical_Chemistry/Supplemental_Modules_(Analytical_Chemistry)/Quantifying_Nature/Significant_Digits/Propagation_of_Error
@@ -304,7 +307,7 @@ TEST(uncertainOps, chemExample1)
     uncertain_measurement path(1.0, 0.1, cm);
     uncertain_measurement absorb(0.172807, 0.000008, one);
 
-    auto eps = absorb.rss_divide(conc.rss_product(path));
+    auto eps = absorb/(conc*path);
     EXPECT_NEAR(eps.value(), 0.013, 0.005);
     EXPECT_NEAR(eps.uncertainty(), 0.001, 0.0005);
 }
@@ -384,9 +387,9 @@ TEST(uncertainOps, testHeight)
     uncertain_measurement t(0.6, 0.06, s);
     measurement gc = 9.8 * m / s.pow(2);
 
-    auto y = v0 * t - 0.5 * gc * pow(t, 2);
+    auto y = v0.simple_product(t).simple_subtract(0.5 * gc * pow(t, 2));
 
-    auto ys = v0.rss_product(t).rss_subtract(0.5 * gc * pow(t, 2));
+    auto ys = v0*t-0.5 * gc * pow(t, 2);
 
     EXPECT_NEAR(y.uncertainty(), 0.712, 0.005);
     EXPECT_NEAR(y.value(), 0.636, 0.0005);

--- a/test/test_unit_ops.cpp
+++ b/test/test_unit_ops.cpp
@@ -536,6 +536,22 @@ TEST(preciseunitOps, inequality1)
     EXPECT_EQ(eqFailNeg, 0);
 }
 
+TEST(preciseunitOps, subnormal_test)
+{
+    precise_unit u1(2.3456e-306, precise::m);
+    precise_unit u2(2.3457e-306, precise::m);
+    //these are equal to within a normal precision floating point.
+    EXPECT_TRUE(u1 == u2);
+    EXPECT_FALSE(u1 != u2);
+    EXPECT_TRUE(u2 == u1);
+
+    precise_unit u3(2.3456e-300, precise::m);
+    precise_unit u4(2.3457e-300, precise::m);
+    //these are not equal.
+    EXPECT_FALSE(u3 == u4);
+    EXPECT_TRUE(u3 != u4);
+    EXPECT_FALSE(u4 == u3);
+}
 TEST(invalidOps, saturate)
 {
     for (int ii = -8; ii < 8; ++ii) {

--- a/units/units.hpp
+++ b/units/units.hpp
@@ -564,12 +564,15 @@ class uncertain_measurement {
   public:
     constexpr uncertain_measurement() = default;
     /// construct from a single precision value, uncertainty, and unit
-    constexpr uncertain_measurement(float val, float uncertainty, unit base) noexcept:
+    constexpr uncertain_measurement(float val, float uncertainty, unit base) noexcept :
         value_(val), uncertainty_(uncertainty), units_(base)
     {
     }
     /// construct from a single precision value, and unit assume uncertainty is 0
-    explicit constexpr uncertain_measurement(float val, unit base) noexcept: value_(val), units_(base) {}
+    explicit constexpr uncertain_measurement(float val, unit base) noexcept :
+        value_(val), units_(base)
+    {
+    }
 
     /// construct from a double precision value, and unit assume uncertainty is 0
     explicit constexpr uncertain_measurement(double val, unit base) noexcept :
@@ -588,7 +591,7 @@ class uncertain_measurement {
     {
     }
     /// construct from a double precision value, uncertainty, and unit
-    explicit constexpr uncertain_measurement(double val, double uncertainty, unit base) noexcept:
+    explicit constexpr uncertain_measurement(double val, double uncertainty, unit base) noexcept :
         value_(static_cast<float>(val)), uncertainty_(static_cast<float>(uncertainty)), units_(base)
     {
     }
@@ -603,11 +606,10 @@ class uncertain_measurement {
     constexpr double value() const { return static_cast<double>(value_); }
     /// Get the uncertainty with no units
     constexpr double uncertainty() const { return static_cast<double>(uncertainty_); }
-	/// Get the base value with no units as a single precision float
-	constexpr float value_f() const { return value_; }
-	/// Get the uncertainty with no units as a single precision float
-	constexpr float uncertainty_f() const { return uncertainty_; }
-
+    /// Get the base value with no units as a single precision float
+    constexpr float value_f() const { return value_; }
+    /// Get the uncertainty with no units as a single precision float
+    constexpr float uncertainty_f() const { return uncertainty_; }
 
     /// Set the uncertainty
     uncertain_measurement& uncertainty(float newUncertainty)
@@ -1215,8 +1217,8 @@ class fixed_precise_measurement {
     /// take the measurement to some power
     constexpr friend fixed_precise_measurement pow(const fixed_precise_measurement& meas, int power)
     {
-        return fixed_precise_measurement{
-            detail::power_const(meas.value_, power), meas.units_.pow(power)};
+        return fixed_precise_measurement{detail::power_const(meas.value_, power),
+                                         meas.units_.pow(power)};
     }
 
     /// Convert a unit to have a new base


### PR DESCRIPTION
This pull request will switch the uncertainty_measurement back to using the rss method for the mathematical operations.  and the secondary functions using the `simple_<op>`  It will also add some documentation for the uncertainty_measurement.  