### PR TITLE
Add to_string option on webserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,17 @@ Add a converter command line application and fix a few slow conversion issues an
 -   A few timeouts on the fuzzer- the fix was to generalize the multiplier insertion after ^ to accept multiple digits after the ^ instead of just ignoring it after more than one. [#34][]  
 -   An asymmetry was observed in the unit equality from on the fuzzers, this resulted in some modifications of the `cround_equal` and `cround_precice_equals` functions.  Also noted that the functions weren't aborting on exact floating point equality so were doing quite a bit of extra calculations. [#34][]
 -   A timeout issue from fuzzing having to do with not injecting multiplies after `[]` in some circumstances.  The fix was to be a little more refined as to which point to not inject the `*` and to do it in multiple stages so as to not rely on the partitioner so much.  [#35][]
-  
+
 ### Added
--   added a [converter](https://units.readthedocs.io/en/latest/introduction/converter.html) command line application that can convert units on the command line [#34][]
+-   added a [converter](https://units.readthedocs.io/en/latest/introduction/converter.html) command line application that can convert units on the command line [#35][]
+-   Added a file operation that can load user defined units from a file  [#36][]
+-   Added `is_valid` methods for all measurement types  [#36][]
+-   Added addUserDefinedInputUnit to add user defined units only on the input  [#36][]
+-   The webserver gained a `to_string` option to use the internal to_string operations to simplify the measurement and units [#37][]
+-   The webserver and the converter gained an ability to handle `*` and `<base>` as the input unit to convert the measurement to base units.  [#37][]
 
 ### Removed
-  
+
 ## [0.3.0][] - 2020-01-28
 
 Continued work on cleaning up the library and starting to add main documentation, as well as adding more units and cleaning up string conversions and some additional tests.  Additional fuzzing fixes and add a webserver for exploring conversions.  
@@ -34,7 +39,7 @@ Continued work on cleaning up the library and starting to add main documentation
 -   Fixed the `UNITS_HEADER_ONLY` target so it actually works and add some tests for it [#23][]
 -   Update the CMake code so it correctly deals with and uses the `CMAKE_CXX_STANDARD` option [#22][]
 -   Some strict aliasing warnings on GCC 6 [#26][]
-  
+
 ### Added
 -   Added pow and root functions to measurements [#7][]
 -   Add sqrt function which is a wrapper function around the root function for measurements and units [#8][]
@@ -69,6 +74,8 @@ Continued work on cleaning up the library and starting to add main documentation
 [#32]: https://github.com/LLNL/units/pull/32
 [#34]: https://github.com/LLNL/units/pull/34
 [#35]: https://github.com/LLNL/units/pull/35
+[#36]: https://github.com/LLNL/units/pull/36
+[#37]: https://github.com/LLNL/units/pull/37
 
 [0.4.0]: https://github.com/LLNL/units/releases/tag/v0.4.0
 [0.3.0]: https://github.com/LLNL/units/releases/tag/v0.3.0

--- a/converter/converter.cpp
+++ b/converter/converter.cpp
@@ -21,8 +21,8 @@ int main(int argc, char* argv[])
         "--simplified,-s",
         simplified,
         "simplify the units using the units library to_string functions and print the conversion string like full will take precedence over full string");
-    
-	std::string measurement;
+
+    std::string measurement;
     app.add_option(
            "--measurement,measure",
            measurement,
@@ -32,21 +32,30 @@ int main(int argc, char* argv[])
         ->required()
         ->join(' ');
     std::string newUnits;
-    app.add_option("--convert,convert", newUnits, "the units to convert the measurement to")
+    app.add_option(
+           "--convert,convert",
+           newUnits,
+           "the units to convert the measurement to, '*' to convert to base units")
         ->required();
     app.positionals_at_end();
 
     CLI11_PARSE(app, argc, argv);
 
     auto meas = units::measurement_from_string(measurement);
-    auto unit = units::unit_from_string(newUnits);
+    units::precise_unit u2;
+    if (newUnits == "*" || newUnits == "<base>") {
+        u2 = meas.convert_to_base().units();
+        newUnits = units::to_string(u2);
+    } else {
+        u2 = units::unit_from_string(newUnits);
+    }
     if (simplified) {
         std::printf(
-            "%s = %g %s\n", to_string(meas).c_str(), meas.value_as(unit), to_string(unit).c_str());
+            "%s = %g %s\n", to_string(meas).c_str(), meas.value_as(u2), to_string(u2).c_str());
     } else if (full_string) {
-        std::printf("%s = %g %s\n", measurement.c_str(), meas.value_as(unit), newUnits.c_str());
+        std::printf("%s = %g %s\n", measurement.c_str(), meas.value_as(u2), newUnits.c_str());
     } else {
-        std::printf("%g\n", meas.value_as(unit));
+        std::printf("%g\n", meas.value_as(u2));
     }
 
     return 0;

--- a/docs/_static/convert.html
+++ b/docs/_static/convert.html
@@ -17,8 +17,11 @@
 
 					<br/>convert to:<br/>
 					<input type="text" id="convert_units" name="units" /><br/>
-          E.g. "inches", "lb", "Gauss", "tsp" <br/><br/>
-					<input type="submit" value="convert" formmethod="post"/>
+          E.g. "inches", "lb", "Gauss", "tsp" <br />
+                "use '*' to convert to base units
+                <br/><br/>
+					 <input type="submit" name="caction" value="convert" formmethod="post" />
+                <input type="submit" name="caction" value="to_string" formmethod="post" />
           <input type="reset">
 			</ul>
 		</form>

--- a/docs/introduction/converter.rst
+++ b/docs/introduction/converter.rst
@@ -21,8 +21,11 @@ As a simple example and potentially useful tool we made the converter app.  It i
    $ ./unit_convert -s four hundred seventy-three kilograms per hour pounds/min
    473 kg/hr = 17.3798 lb/min
 
+   $ ./unit_convert -s 22 british fathoms *
+   10 british fathoms = 18.288 m
 
-basically there are two options `--full,-f` and `--simplified,-s`  a measurement which will take an arbitrary number of strings and a final string as a unit to convert to.  It outputs the conversion and if specified the surrounding measurement and units either simplified or in the original.
+
+basically there are two options `--full,-f` and `--simplified,-s`  a measurement which will take an arbitrary number of strings and a final string as a unit to convert to.  It outputs the conversion and if specified the surrounding measurement and units either simplified or in the original.  Using `*` or `<base>` in place of the unit string will result in converting the measurement to base units.
 
 .. code-block:: bash
 

--- a/docs/web/index.rst
+++ b/docs/web/index.rst
@@ -21,18 +21,18 @@ the unit string should be some unit that is convertible from the measurement uni
 -   `kiB`
 -   `british fathoms`
 
-The conversion also supports mathematical operations  see :ref:`Units From Strings` for additional details on string conversions
+The conversion also supports mathematical operations  see :ref:`Units From Strings` for additional details on string conversions.  The units can also be set to `*`or `<base>` to convert the measurement to base units.
 
 Rest API
 -----------
 
 The units web server does not serve files, it generates all responses on the fly.  There are 3 URI indicators it responds to beyond the root page.
 
--  `/convert`  : respond with an html page
--  `/convert_trivial` : respond with the results as a simple text
--  `/convert_json` : respond with a json string containing the requested conversions and the results.
+-  `/convert`  : responds with an html page
+-  `/convert_trivial` : responds with the results as a simple text
+-  `/convert_json` : responds with a json string containing the requested conversions and the results.
 
-For example in linux or anything with curl
+For example in Linux or anything with curl
 
 .. code-block:: bash
 
@@ -41,9 +41,20 @@ For example in linux or anything with curl
 
    $ curl -s "13.52.135.81/convert_json?measurement=10%20tons&units=lb"
    {
-   "measurement":"10 tons",
-   "units":"lb",
-   "value":"20000"
+   "request_measurement":"",
+   "request_units":"lb"",
+   "measurement":"",
+   "units":"lb"",
+   "value":"nan"
    }
 
-This works with POST or GET methods
+    $ curl -s "13.52.135.81/convert_json?measurement=ten%20meterspersecond&units=feetperminute&caction=to_string"
+   {
+   "request_measurement":"ten meterspersecond",
+   "request_units":"feetperminute",
+   "measurement":"10 m/s",
+   "units":"ft/min",
+   "value":"1968.5"
+   }
+
+This works with POST or GET methods.  The `caction` field can be set to "to_string" this will "simplify" the units in the result or at least use the internal to_string operations to convert to an interpretable string in more accessible units.   

--- a/webserver/convert.html
+++ b/webserver/convert.html
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
 	<head>
 		<meta charset="utf-8" />
 		<title>Units Library String Conversions</title>
@@ -10,15 +10,25 @@
 			<a href="https://units.readthedocs.io/en/latest/index.html">Documentation</a></h2>
 
 		<form action="/convert" method="post">
-			<ul>
-					Measurement string:<br/>
-					<input type="text" id="m_string" name="measurement" value="$M1$" /><br/>
-          E.g.  "25 m", "ten tons", "3.252Tesla", "237uL" <br/>
-					<br/>convert to (units):<br/>
-					<input type="text" id="convert_units" name="units"  value="$U1$"/><br/>
-          E.g. "inches", "lb", "Gauss", "tsp" <br/><br/>
-					<input type="submit" value="convert" formmethod="post"/>
-			</ul>
+            <ul>
+                Measurement string:
+                <br />
+                <input type="text" id="m_string" name="measurement" value="$M1$" />
+                <br />
+                E.g.  "25 m", "ten tons", "3.252Tesla", "237uL"
+                <br />
+                <br />convert to (units):
+                <br />
+                <input type="text" id="convert_units" name="units" value="$U1$" />
+                <br />
+                E.g. "inches", "lb", "Gauss", "tsp"
+                <br />
+                "use '*' to convert to base units
+                <br />
+                <br />
+                <input type="submit" name="caction" value="convert" formmethod="post" />
+                <input type="submit" name="caction" value="simplify" formmethod="post" />
+            </ul>
 		</form>
 		$M1$ = <font size="5" color="blue"><strong>$VALUE$</strong></font> $U1$
 	</body>

--- a/webserver/convert.html
+++ b/webserver/convert.html
@@ -27,9 +27,10 @@
                 <br />
                 <br />
                 <input type="submit" name="caction" value="convert" formmethod="post" />
-                <input type="submit" name="caction" value="simplify" formmethod="post" />
+                <input type="submit" name="caction" value="to_string" formmethod="post" />
+                <input type="submit" name="caction" value="reset" formmethod="post" />
             </ul>
 		</form>
-		$M1$ = <font size="5" color="blue"><strong>$VALUE$</strong></font> $U1$
+		$M2$ = <font size="5" color="blue"><strong>$VALUE$</strong></font> $U2$
 	</body>
 </html>

--- a/webserver/index.html
+++ b/webserver/index.html
@@ -9,18 +9,25 @@
 		<h2><a href="https://github.com/LLNL/units">Source</a>
 			<a href="https://units.readthedocs.io/en/latest/index.html">Documentation</a></h2>
 		<form action="/convert" method="post">
-			<ul>
-					Measurement string:<br/>
-					<input type="text" id="m_string" name="measurement" /><br/>
-          E.g.  "25 m", "ten tons", "3.252Tesla", "237uL" <br/>
+            <ul>
+                Measurement string:
+                <br />
+                <input type="text" id="m_string" name="measurement" />
+                <br />
+                E.g.  "25 m", "ten tons", "3.252Tesla", "237uL"
+                <br />
 
-					<br/>convert to:<br/>
-					<input type="text" id="convert_units" name="units" /><br/>
-          E.g. "inches", "lb", "Gauss", "tsp" <br/> "use '*' to convert to base units<br/><br/>
-					<input type="submit" name="caction" value="convert" formmethod="post"/>
-                <input type="submit" name="caction" value="simplify" formmethod="post"/>
-          <input type="reset">
-			</ul>
+                <br />convert to:
+                <br />
+                <input type="text" id="convert_units" name="units" />
+                <br />
+                E.g. "inches", "lb", "Gauss", "tsp"
+                <br /> "use '*' to convert to base units
+                <br />
+                <input type="submit" name="caction" value="convert" formmethod="post" />
+                <input type="submit" name="caction" value="to_string" formmethod="post" />
+                <input type="reset">
+            </ul>
 		</form>
 	</body>
 </html>

--- a/webserver/index.html
+++ b/webserver/index.html
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
 	<head>
 		<meta charset="utf-8" />
 		<title>Units Library String Conversions</title>
@@ -10,15 +10,15 @@
 			<a href="https://units.readthedocs.io/en/latest/index.html">Documentation</a></h2>
 		<form action="/convert" method="post">
 			<ul>
-
 					Measurement string:<br/>
 					<input type="text" id="m_string" name="measurement" /><br/>
           E.g.  "25 m", "ten tons", "3.252Tesla", "237uL" <br/>
 
 					<br/>convert to:<br/>
 					<input type="text" id="convert_units" name="units" /><br/>
-          E.g. "inches", "lb", "Gauss", "tsp" <br/><br/>
-					<input type="submit" value="convert" formmethod="post"/>
+          E.g. "inches", "lb", "Gauss", "tsp" <br/> "use '*' to convert to base units<br/><br/>
+					<input type="submit" name="caction" value="convert" formmethod="post"/>
+                <input type="submit" name="caction" value="simplify" formmethod="post"/>
           <input type="reset">
 			</ul>
 		</form>

--- a/webserver/unit_web_server.cpp
+++ b/webserver/unit_web_server.cpp
@@ -55,7 +55,7 @@ static std::string loadFile(const std::string& fileName)
 static const std::string index_page = loadFile("index.html");
 static const std::string response_page = loadFile("convert.html");
 static const std::string response_json =
-    "{\n\"measurement\":\"$M1$\",\n\"units\":\"$U1$\",\n\"value\":\"$VALUE$\"\n}";
+    "{\n\"request_measurement\":\"$M1$\",\n\"request_units\":\"$U1$\",\n\"measurement\":\"$M2$\",\n\"units\":\"$U2$\",\n\"value\":\"$VALUE$\"\n}";
 
 //decode a uri to clean up a string, convert character codes in a uri to the original character
 static std::string uri_decode(beast::string_view str)
@@ -81,6 +81,25 @@ static std::string uri_decode(beast::string_view str)
         }
     }
     return ret;
+}
+
+static void
+    string_substitution_single(std::string& page, const std::string& search, const std::string& rep)
+{
+    auto v = page.find(search);
+    while (v != std::string::npos) {
+        page.replace(v, search.size(), rep);
+        v = page.find(search);
+    }
+}
+
+static void string_substitution(
+    std::string& page,
+    const std::vector<std::pair<std::string, std::string>>& subs)
+{
+    for (const auto& sub_pair : subs) {
+        string_substitution_single(page, sub_pair.first, sub_pair.second);
+    }
 }
 
 // function to extract the request parameters and clean up the target
@@ -189,29 +208,16 @@ void handle_request(http::request<Body, http::basic_fields<Allocator>>&& req, Se
     };
 
     // generate a conversion response
-    auto const conversion_response =
-        [&req](const std::string& value, const std::string& M1, const std::string& U1) {
+    auto const html_response =
+        [&req](
+            const std::string& html_page,
+            const std::vector<std::pair<std::string, std::string>>& substitutions) {
             http::response<http::string_body> res{http::status::ok, req.version()};
             res.set(http::field::server, BOOST_BEAST_VERSION_STRING);
             res.set(http::field::content_type, "text/html");
             res.keep_alive(req.keep_alive());
-            auto resp = response_page;
-            auto v = resp.find("$M1$");
-            while (v != std::string::npos) {
-                resp.replace(v, 4, M1);
-                v = resp.find("$M1$");
-            }
-
-            v = resp.find("$U1$", v + 4);
-            while (v != std::string::npos) {
-                resp.replace(v, 4, U1);
-                v = resp.find("$U1$");
-            }
-            v = resp.find("$VALUE$", v + 4);
-            while (v != std::string::npos) {
-                resp.replace(v, 7, value);
-                v = resp.find("$VALUE$");
-            }
+            auto resp = html_page;
+            string_substitution(resp, substitutions);
 
             if (req.method() != http::verb::head) {
                 res.body() = resp;
@@ -222,7 +228,7 @@ void handle_request(http::request<Body, http::basic_fields<Allocator>>&& req, Se
             return res;
         };
     // generate a conversion response
-    auto const conversion_response_trivial = [&req](const std::string& value) {
+    auto const trivial_response = [&req](const std::string& value) {
         http::response<http::string_body> res{http::status::ok, req.version()};
         res.set(http::field::server, BOOST_BEAST_VERSION_STRING);
         res.set(http::field::content_type, "text/plain");
@@ -237,19 +243,16 @@ void handle_request(http::request<Body, http::basic_fields<Allocator>>&& req, Se
     };
 
     // generate a conversion response
-    auto const conversion_response_json =
-        [&req](const std::string& value, const std::string& M1, const std::string& U1) {
+    auto const json_response =
+        [&req](
+            const std::string& json_string,
+            const std::vector<std::pair<std::string, std::string>>& substitutions) {
             http::response<http::string_body> res{http::status::ok, req.version()};
             res.set(http::field::server, BOOST_BEAST_VERSION_STRING);
             res.set(http::field::content_type, "application/json");
             res.keep_alive(req.keep_alive());
-            auto resp = response_json;
-            auto v = resp.find("$M1$");
-            resp.replace(v, 4, M1);
-            v = resp.find("$U1$", v + 4);
-            resp.replace(v, 4, U1);
-            v = resp.find("$VALUE$", v + 4);
-            resp.replace(v, 7, value);
+            auto resp = json_string;
+            string_substitution(resp, substitutions);
 
             if (req.method() != http::verb::head) {
                 res.body() = resp;
@@ -295,30 +298,37 @@ void handle_request(http::request<Body, http::basic_fields<Allocator>>&& req, Se
                 bad_request("conversion units string size exceeds limits of 256 characters"));
         }
     }
-    bool simplify = false;
+    bool tstring{false};
     if (fields.find("caction") != fields.end()) {
-        if (fields["caction"] == "simplify") {
-            simplify = true;
+        if (fields["caction"] == "to_string") {
+            tstring = true;
+        } else if (fields["caction"] == "reset") {
+            return send(main_page());
         }
     }
     auto meas = units::measurement_from_string(measurement);
     units::precise_unit u2;
     if (toUnits == "*" || toUnits == "<base>") {
-		u2 = meas.convert_to_base().units();
-		toUnits = units::to_string(u2);
+        u2 = meas.convert_to_base().units();
+        toUnits = units::to_string(u2);
     } else {
         u2 = units::unit_from_string(toUnits);
     }
 
     auto Vstr = as_string(meas.value_as(u2));
-    std::string string1 = (simplify) ? units::to_string(meas) : measurement;
-    std::string string2 = (simplify) ? units::to_string(u2) : toUnits;
+    std::vector<std::pair<std::string, std::string>> substitutions{
+        {"$M1$", measurement},
+        {"$U1$", toUnits},
+        {"$VALUE$", Vstr},
+        {"$M2$", (tstring) ? units::to_string(meas) : measurement},
+        {"$U2$", (tstring) ? units::to_string(u2) : toUnits}};
+
     if (reqpr.first == "convert") {
-        return send(conversion_response(Vstr, string1, string2));
+        return send(html_response(response_page, substitutions));
     } else if (reqpr.first == "convert_json") {
-        return send(conversion_response_json(Vstr, string1, string2));
+        return send(json_response(response_json, substitutions));
     } else {
-        return send(conversion_response_trivial(Vstr));
+        return send(trivial_response(Vstr));
     }
 }
 


### PR DESCRIPTION
add a to_string operation to the webserver, and allow for special operation to convert to base units. 
Do some refactoring of the webserver to simplify the logic.  Update the documentation appropriately.  