### PR TITLE
nicer string output

### DIFF
--- a/docs/user-guide/to_string.rst
+++ b/docs/user-guide/to_string.rst
@@ -15,7 +15,7 @@ For example
    auto str2=to_string(meas2);
 
    // from google tests
-   EXPECT_EQ(str1, "10 g/L");
+   EXPECT_EQ(str1, "10 kg/m^3");
    EXPECT_EQ(str2, "2.7 puMW");
 
 

--- a/test/test_measurement_strings.cpp
+++ b/test/test_measurement_strings.cpp
@@ -76,7 +76,7 @@ TEST(MeasurementToString, test)
     auto str2 = to_string(meas2);
 
     // from google tests
-    EXPECT_EQ(str1, "10 g/L");
+    EXPECT_EQ(str1, "10 kg/m^3");
     EXPECT_EQ(str2, "2.7 puMW");
 }
 

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -101,9 +101,9 @@ TEST(unitStrings, prefixes)
     EXPECT_EQ(to_string(precise::micro * precise::L), "uL");
 }
 
-TEST(unitStrings, readability) 
+TEST(unitStrings, readability)
 {
-    EXPECT_EQ(to_string(precise::m/precise::s.pow(2)), "m/s^2");
+    EXPECT_EQ(to_string(precise::m / precise::s.pow(2)), "m/s^2");
 }
 
 TEST(unitStrings, infinite)

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -101,6 +101,11 @@ TEST(unitStrings, prefixes)
     EXPECT_EQ(to_string(precise::micro * precise::L), "uL");
 }
 
+TEST(unitStrings, readability) 
+{
+    EXPECT_EQ(to_string(precise::m/precise::s.pow(2)), "m/s^2");
+}
+
 TEST(unitStrings, infinite)
 {
     EXPECT_EQ(

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -78,8 +78,8 @@ unit root(unit un, int power)
     if (un.multiplier() < 0.0 && power % 2 == 0) {
         return error;
     }
-    return unit{
-        un.base_units().root(power), numericalRoot(un.multiplier(), power)};
+    return unit{un.base_units().root(power),
+                numericalRoot(un.multiplier(), power)};
 }
 
 precise_unit root(precise_unit un, int power)
@@ -90,8 +90,8 @@ precise_unit root(precise_unit un, int power)
     if (un.multiplier() < 0.0 && power % 2 == 0) {
         return precise::invalid;
     }
-    return precise_unit{
-        un.base_units().root(power), numericalRoot(un.multiplier(), power)};
+    return precise_unit{un.base_units().root(power),
+                        numericalRoot(un.multiplier(), power)};
 }
 
 measurement root(const measurement& meas, int power)
@@ -1447,9 +1447,8 @@ static double getPrefixMultiplier2Char(char c1, char c2)
     static UNITS_CPP14_CONSTEXPR_OBJECT std::array<cpair, 23> char2prefix{{
         cpair{charindex('D', 'A'), 10.0},
         cpair{charindex('E', 'X'), 1e18},
-        cpair{
-            charindex('E', 'i'),
-            1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0},
+        cpair{charindex('E', 'i'),
+              1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0},
         cpair{charindex('G', 'A'), 1e9},
         cpair{charindex('G', 'i'), 1024.0 * 1024.0 * 1024.0},
         cpair{charindex('K', 'i'), 1024.0},
@@ -1462,15 +1461,13 @@ static double getPrefixMultiplier2Char(char c1, char c2)
         cpair{charindex('T', 'i'), 1024.0 * 1024.0 * 1024.0 * 1024.0},
         cpair{charindex('Y', 'A'), 1e24},
         cpair{charindex('Y', 'O'), 1e-24},
-        cpair{
-            charindex('Y', 'i'),
-            1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 *
-                1024.0},
+        cpair{charindex('Y', 'i'),
+              1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 *
+                  1024.0},
         cpair{charindex('Z', 'A'), 1e21},
         cpair{charindex('Z', 'O'), 1e-21},
-        cpair{
-            charindex('Z', 'i'),
-            1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0},
+        cpair{charindex('Z', 'i'),
+              1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0},
         cpair{charindex('d', 'a'), 10.0},
         cpair{charindex('m', 'A'), 1e6},
         cpair{charindex('m', 'c'), 1e-6},
@@ -1886,10 +1883,9 @@ static UNITS_CPP14_CONSTEXPR_OBJECT std::array<utup, 29> prefixWords{{
     utup{"zepto", 1e-21, 5},
     utup{"zetta", 1e21, 5},
     utup{"zebi", 1024.0 * 1024.0 * 1024 * 1024.0 * 1024.0 * 1024.0 * 1024.0, 4},
-    utup{
-        "yobi",
-        1024.0 * 1024.0 * 1024 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0,
-        4},
+    utup{"yobi",
+         1024.0 * 1024.0 * 1024 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0,
+         4},
 }};
 
 bool clearEmptySegments(std::string& unit)
@@ -6314,9 +6310,8 @@ precise_measurement measurement_from_string(
     if (!is_error(un)) {
         if (checkCurrency) {
             if (un.base_units() == precise::currency.base_units()) {
-                return {
-                    un.multiplier(),
-                    precise_unit(1.0, precise::currency, un.commodity())};
+                return {un.multiplier(),
+                        precise_unit(1.0, precise::currency, un.commodity())};
             }
         }
         return {val, un};

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -1099,7 +1099,7 @@ static std::string
             return std::string("1/") + fnd + "^3";
         }
     }
-    
+
     if (un.is_equation()) {
         auto ubase = un.base_units();
         int num = precise::custom::eq_type(ubase);
@@ -1227,7 +1227,6 @@ static std::string
             return std::string("1/(") + fnd + '*' + tu.second + ')';
         }
     }
-    
 
     std::string beststr;
     // let's try common divisor units on base units


### PR DESCRIPTION
switch the order of some of the string conversion sections to prioritize short units so m/s^2 shows up in a nicer fashion.