### PR TITLE
std::abs usage

### DIFF
--- a/test/test_ucum.cpp
+++ b/test/test_ucum.cpp
@@ -130,7 +130,7 @@ TEST(UCUM, TestAllVerify)
         EXPECT_NEAR(mag / csact.multiplier(), 1.0, 0.01)
             << csCode << ":error in magnitude " << mag << " to "
             << csact.multiplier();
-        if (std::abs(mag / csact.multiplier() - 1.0) >= 0.01) {
+        if (std::fabs(mag / csact.multiplier() - 1.0) >= 0.01) {
             ++magError;
         }
     }
@@ -614,7 +614,7 @@ TEST(UCUMConversions, convert1)
         EXPECT_FALSE(std::isnan(act));
         if (!std::isnan(act)) {
             EXPECT_NEAR(outcome, act, 0.001 * outcome);
-            if (std::abs(outcome - act) / outcome > 0.001) {
+            if (std::fabs(outcome - act) / outcome > 0.001) {
                 std::cout << unitFromString << " and " << unitToString
                           << " do not convert " << act
                           << " and expected=" << outcome << '\n';

--- a/units/unit_definitions.hpp
+++ b/units/unit_definitions.hpp
@@ -11,6 +11,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <algorithm>
 #include <array>
 #include <limits>
+#include <cstdlib>
 
 namespace units {
 /// Constants used in definitions of units
@@ -870,7 +871,7 @@ namespace precise {
                 // mole is always -2 regardless of inversion
                 return false;
             }
-            if (std::abs(UT.ampere()) < 2) {
+            if (std::labs(UT.ampere()) < 2) {
                 // ampere is either -3 or -4  or 3 or 4
                 return false;
             }
@@ -882,13 +883,13 @@ namespace precise {
         {
             int num = (UT.has_e_flag() ? 1 : 0) + (UT.has_i_flag() ? 2 : 0) +
                 (UT.is_per_unit() ? 4 : 0);
-            num += (std::abs(UT.meter()) < 4) ? 256 : 0;
-            num += (std::abs(UT.second()) >= 6) ? 512 : 0;
-            num += (std::abs(UT.kg()) <= 1) ? 128 : 0;
-            num += (std::abs(UT.kelvin()) == 3) ? 16 : 0;
+            num += (std::labs(UT.meter()) < 4) ? 256 : 0;
+            num += (std::labs(UT.second()) >= 6) ? 512 : 0;
+            num += (std::labs(UT.kg()) <= 1) ? 128 : 0;
+            num += (std::labs(UT.kelvin()) == 3) ? 16 : 0;
             num += (UT.ampere() == -4) ? 64 : 0;
-            num += (std::abs(UT.candela()) >= 2) ? 0 : 32;
-            num += (std::abs(UT.currency()) >= 2) ? 8 : 0;
+            num += (std::labs(UT.candela()) >= 2) ? 0 : 32;
+            num += (std::labs(UT.currency()) >= 2) ? 8 : 0;
             return num;
         }
         /// check if 1/custom unit

--- a/units/unit_definitions.hpp
+++ b/units/unit_definitions.hpp
@@ -10,8 +10,8 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <algorithm>
 #include <array>
-#include <limits>
 #include <cstdlib>
+#include <limits>
 
 namespace units {
 /// Constants used in definitions of units

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -126,10 +126,10 @@ fixed_precise_measurement root(const fixed_precise_measurement& fpm, int power)
 static int order(unit val)
 {
     auto bd = val.base_units();
-    int order = std::abs(bd.meter()) + std::abs(bd.kelvin()) +
-        std::abs(bd.kg()) + std::abs(bd.count()) + std::abs(bd.ampere()) +
-        std::abs(bd.second()) + std::abs(bd.currency()) +
-        std::abs(bd.radian()) + std::abs(bd.candela()) + std::abs(bd.mole());
+    int order = std::labs(bd.meter()) + std::labs(bd.kelvin()) +
+        std::labs(bd.kg()) + std::labs(bd.count()) + std::labs(bd.ampere()) +
+        std::labs(bd.second()) + std::labs(bd.currency()) +
+        std::labs(bd.radian()) + std::labs(bd.candela()) + std::labs(bd.mole());
     return order;
 }
 
@@ -1535,7 +1535,7 @@ static double
         return -constants::infinity;
     }
     // floating point min gives you the smallest representable positive value
-    if (std::abs(vld) <
+    if (std::fabs(vld) <
         static_cast<long double>(std::numeric_limits<double>::min())) {
         return 0.0;
     }
@@ -5124,7 +5124,7 @@ static void checkPowerOf10(std::string& unit_string)
                 if (looksLikeInteger(powerstr)) {
                     try {
                         int power = std::stoi(powerstr);
-                        if (std::abs(power) <= 38) {
+                        if (std::labs(power) <= 38) {
                             unit_string.replace(fndP, 3, "1e");
                         }
                     }


### PR DESCRIPTION
replace use of std::abs with std::fabs or std::labs as appropriate for better compatibility with older compilers