### PR TITLE
Custom count unit docs

### DIFF
--- a/docs/user-guide/custom_count_units.rst
+++ b/docs/user-guide/custom_count_units.rst
@@ -2,7 +2,7 @@
 Custom Counting Units
 ======================
 
-The units library defines 16 special counting units.  These are custom counting units intended to specify a specific type of event.  The key idea behind the custom counting units is that they can be multiplied, divided by any powers of distance, mass, currency, or time units and can be inverted
+The units library defines 16 special counting units.  These are custom counting units intended to specify a specific type of event.  The key idea behind the custom counting units is that they can be multiplied, divided by any powers of distance, mass, currency, or time units and can be inverted. The primary usage of these is for units that are procedurally defined and often used in the context of per mass or per volume or per time or per $.
 
 In strings these can be represented by "CXCUN[X]"  Where X is some number between 0 and 15.
 
@@ -32,10 +32,9 @@ So there is no translation to other units and cannot be converted except to mult
 -   custom_count_unit(3):  is `Index of reactivity <http://finto.fi/ucum/en/page/r394>`_ which has a clinical definition
 -   custom_count_unit(4):  is `limit of flocculation <http://finto.fi/ucum/en/page/r404>`_ which has a clinical definition
 -   custom_count_unit(5):  is `HPF <https://medical-dictionary.thefreedictionary.com/high-power+field>`_ or High Power field which is related to microscopy
+-   6-15 are not currently in use.
 
 The other custom units are available for use or the one with known definition can be use if there is no domain conflicts.
-
-The primary usage of these is for units that are procedurally defined and often used in the context of per mass or per volume or per time.
 
 Implementation details
 ----------------------------

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -19,3 +19,5 @@ The guide covers the basic types and what operations are available on them, as w
    user_defined_units
    Physical_constants
    defined_units
+   custom_units
+   custom_count_units

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -167,7 +167,8 @@ static const umap base_unit_names{
     {pico * H, "(A^-2*pJ)"},
     {lm, "lm"},
     {lx, "lux"},
-    {Bq, "Bq"},
+    // remove Bq since it is often confusing in other contexts 1/s
+    // {Bq, "Bq"},
     {unit(2.58e-4, C / kg), "R"},
     {in, "in"},
     {unit_cast(precise::in.pow(2)), "in^2"},


### PR DESCRIPTION
add custom units and custom count units docs into the documentation links,  remove Becquerel from the generated units sequences.

Closes #80 