### PR TITLE
add some case insensitive unit test for two character units.

### DIFF
--- a/test/test_measurement_strings.cpp
+++ b/test/test_measurement_strings.cpp
@@ -90,3 +90,62 @@ TEST(MeasurementToString, unit_withNumbers)
     EXPECT_EQ(str1.compare(0, 11, "10 (0.71241"), 0);
     EXPECT_EQ(str2.compare(0, 11, "10 (0.71241"), 0);
 }
+
+TEST(MeasurementToString, case_sensitive) {
+    static const std::vector<std::pair<unit, std::string>>twoc_units{
+        {lb, "lb"}, {oz, "oz"}, {yd, "yd"}, {unit_cast(precise::us::quart), "qt"}};
+
+    for (auto &up:twoc_units) {
+
+        std::string singular = std::string("17 ") + up.second;
+        std::string plural = singular;
+        plural.push_back('s');
+
+        std::string singular_caps = singular;
+        std::transform(
+            singular.begin(), singular.end(), singular_caps.begin(), ::toupper);
+
+        std::string plural_caps = plural;
+        std::transform(
+            plural.begin(), plural.end(),plural_caps.begin(), ::toupper);
+
+    precise_measurement case_sensitive_plural =
+        measurement_from_string(plural);
+    // true
+    EXPECT_TRUE(case_sensitive_plural.units().has_same_base(up.first));
+    precise_measurement case_sensitive_singular =
+        measurement_from_string(singular);
+    EXPECT_TRUE(case_sensitive_singular.units().has_same_base(up.first));
+
+    // Case insensitive string conversion
+    precise_measurement case_insensitive_plural =
+        measurement_from_string(plural, case_insensitive);
+    // true
+    EXPECT_TRUE(case_insensitive_plural.units().has_same_base(up.first))
+        << up.second;
+
+    units::precise_measurement case_insensitive_singular =
+        measurement_from_string(singular, case_insensitive);
+    // false
+    EXPECT_TRUE(case_insensitive_singular.units().has_same_base(up.first));
+
+
+     // Case insensitive string conversion caps
+    precise_measurement case_insensitive_plural_caps =
+        measurement_from_string(plural_caps, case_insensitive);
+    // true
+    EXPECT_TRUE(case_insensitive_plural_caps.units().has_same_base(up.first));
+
+    units::precise_measurement case_insensitive_singular_caps =
+        measurement_from_string(singular_caps, case_insensitive);
+    // false
+    EXPECT_TRUE(case_insensitive_singular_caps.units().has_same_base(up.first));
+
+    // Round trip
+    const std::string case_insensitive_plural_str =
+        units::to_string(case_insensitive_plural);
+    units::precise_measurement round_trip = units::measurement_from_string(
+        case_insensitive_plural_str, units::case_insensitive);
+    EXPECT_TRUE(round_trip.units().has_same_base(up.first));
+    }
+}

--- a/test/test_measurement_strings.cpp
+++ b/test/test_measurement_strings.cpp
@@ -91,12 +91,15 @@ TEST(MeasurementToString, unit_withNumbers)
     EXPECT_EQ(str2.compare(0, 11, "10 (0.71241"), 0);
 }
 
-TEST(MeasurementToString, case_sensitive) {
-    static const std::vector<std::pair<unit, std::string>>twoc_units{
-        {lb, "lb"}, {oz, "oz"}, {yd, "yd"}, {unit_cast(precise::us::quart), "qt"}};
+TEST(MeasurementToString, case_sensitive)
+{
+    static const std::vector<std::pair<unit, std::string>> twoc_units{
+        {lb, "lb"},
+        {oz, "oz"},
+        {yd, "yd"},
+        {unit_cast(precise::us::quart), "qt"}};
 
-    for (auto &up:twoc_units) {
-
+    for (auto& up : twoc_units) {
         std::string singular = std::string("17 ") + up.second;
         std::string plural = singular;
         plural.push_back('s');
@@ -107,45 +110,46 @@ TEST(MeasurementToString, case_sensitive) {
 
         std::string plural_caps = plural;
         std::transform(
-            plural.begin(), plural.end(),plural_caps.begin(), ::toupper);
+            plural.begin(), plural.end(), plural_caps.begin(), ::toupper);
 
-    precise_measurement case_sensitive_plural =
-        measurement_from_string(plural);
-    // true
-    EXPECT_TRUE(case_sensitive_plural.units().has_same_base(up.first));
-    precise_measurement case_sensitive_singular =
-        measurement_from_string(singular);
-    EXPECT_TRUE(case_sensitive_singular.units().has_same_base(up.first));
+        precise_measurement case_sensitive_plural =
+            measurement_from_string(plural);
+        // true
+        EXPECT_TRUE(case_sensitive_plural.units().has_same_base(up.first));
+        precise_measurement case_sensitive_singular =
+            measurement_from_string(singular);
+        EXPECT_TRUE(case_sensitive_singular.units().has_same_base(up.first));
 
-    // Case insensitive string conversion
-    precise_measurement case_insensitive_plural =
-        measurement_from_string(plural, case_insensitive);
-    // true
-    EXPECT_TRUE(case_insensitive_plural.units().has_same_base(up.first))
-        << up.second;
+        // Case insensitive string conversion
+        precise_measurement case_insensitive_plural =
+            measurement_from_string(plural, case_insensitive);
+        // true
+        EXPECT_TRUE(case_insensitive_plural.units().has_same_base(up.first))
+            << up.second;
 
-    units::precise_measurement case_insensitive_singular =
-        measurement_from_string(singular, case_insensitive);
-    // false
-    EXPECT_TRUE(case_insensitive_singular.units().has_same_base(up.first));
+        units::precise_measurement case_insensitive_singular =
+            measurement_from_string(singular, case_insensitive);
+        // false
+        EXPECT_TRUE(case_insensitive_singular.units().has_same_base(up.first));
 
+        // Case insensitive string conversion caps
+        precise_measurement case_insensitive_plural_caps =
+            measurement_from_string(plural_caps, case_insensitive);
+        // true
+        EXPECT_TRUE(
+            case_insensitive_plural_caps.units().has_same_base(up.first));
 
-     // Case insensitive string conversion caps
-    precise_measurement case_insensitive_plural_caps =
-        measurement_from_string(plural_caps, case_insensitive);
-    // true
-    EXPECT_TRUE(case_insensitive_plural_caps.units().has_same_base(up.first));
+        units::precise_measurement case_insensitive_singular_caps =
+            measurement_from_string(singular_caps, case_insensitive);
+        // false
+        EXPECT_TRUE(
+            case_insensitive_singular_caps.units().has_same_base(up.first));
 
-    units::precise_measurement case_insensitive_singular_caps =
-        measurement_from_string(singular_caps, case_insensitive);
-    // false
-    EXPECT_TRUE(case_insensitive_singular_caps.units().has_same_base(up.first));
-
-    // Round trip
-    const std::string case_insensitive_plural_str =
-        units::to_string(case_insensitive_plural);
-    units::precise_measurement round_trip = units::measurement_from_string(
-        case_insensitive_plural_str, units::case_insensitive);
-    EXPECT_TRUE(round_trip.units().has_same_base(up.first));
+        // Round trip
+        const std::string case_insensitive_plural_str =
+            units::to_string(case_insensitive_plural);
+        units::precise_measurement round_trip = units::measurement_from_string(
+            case_insensitive_plural_str, units::case_insensitive);
+        EXPECT_TRUE(round_trip.units().has_same_base(up.first));
     }
 }

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -2662,6 +2662,7 @@ static const smap base_unit_vals{
     {"foot_i", precise::i::foot},
     {"feet", precise::ft},
     {"feet_i", precise::i::foot},
+    {"YD", precise::yd},
     {"yd", precise::yd},
     {"yd_i", precise::yd},
     {"yard_i", precise::yd},
@@ -2769,6 +2770,7 @@ static const smap base_unit_vals{
     {"wk", precise::time::week},
     {"WK", precise::time::week},
     {"y", precise::time::year},
+    {"YR", precise::time::yr},  // this one gets 365 days exactly
     {"yr", precise::time::yr},  // this one gets 365 days exactly
     {"a", precise::time::year},  // year vs are
     {"year", precise::time::year},  // year
@@ -3634,6 +3636,7 @@ static const smap base_unit_vals{
     {"registerton", precise_unit(100.0, precise::ft.pow(3))},
     {"waterton", precise_unit(224.0, precise::imp::gallon)},
     {"lb", precise::lb},
+    {"LB", precise::lb},
     {"kip", precise::kilo* precise::lb},
     {"lb_tr", precise::troy::pound},
     {"[LB_TR]", precise::troy::pound},
@@ -3733,6 +3736,7 @@ static const smap base_unit_vals{
     {"liquidounce", precise::us::floz},
     {"liquidoz", precise::us::floz},
     {"oz", precise::oz},
+    {"OZ", precise::oz},
     {u8"\u2125", precise::oz},
     {"gr", precise::i::grain},
     {"[GR]", precise::i::grain},
@@ -3930,9 +3934,12 @@ static const smap base_unit_vals{
     {"liquidounce_m", precise::metric::floz},
     {"quart", precise::us::quart},
     {"qt", precise::us::quart},
+    {"QT", precise::us::quart},
     {"qt_us", precise::us::quart},
     {"[QT_US]", precise::us::quart},
     {"quart_us", precise::us::quart},
+    {"pt", precise::us::pint},
+    {"PT", precise::us::pint},
     {"pint", precise::us::pint},
     {"pint_us", precise::us::pint},
     {"pt_us", precise::us::pint},


### PR DESCRIPTION
FIx case insensitive pounds  and a few other units which wasn't working with plural units.

Fixes Issue #90.  

Issues fixed include "lb", "oz", "qt", "yd"  

case insensitive "pt" is also fixed but plural reads at peta seconds in case_insensitive mode