### PR TITLE
add better options for optimal string on multiplier generation

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,14 @@ else()
     target_compile_definitions(
         test_unit_strings PUBLIC -DTEST_FILE_FOLDER="${TEST_FILE_FOLDER}"
     )
+
+    target_compile_definitions(
+        test_unit_strings PUBLIC -DENABLE_UNIT_TESTING=1
+    )
+    target_compile_definitions(
+        test_leadingNumbers PUBLIC -DENABLE_UNIT_TESTING=1
+    )
+
     target_compile_definitions(
         test_conversions2 PUBLIC -DTEST_FILE_FOLDER="${TEST_FILE_FOLDER}"
     )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,12 +48,8 @@ else()
         test_unit_strings PUBLIC -DTEST_FILE_FOLDER="${TEST_FILE_FOLDER}"
     )
 
-    target_compile_definitions(
-        test_unit_strings PUBLIC -DENABLE_UNIT_TESTING=1
-    )
-    target_compile_definitions(
-        test_leadingNumbers PUBLIC -DENABLE_UNIT_TESTING=1
-    )
+    target_compile_definitions(test_unit_strings PUBLIC -DENABLE_UNIT_TESTING=1)
+    target_compile_definitions(test_leadingNumbers PUBLIC -DENABLE_UNIT_TESTING=1)
 
     target_compile_definitions(
         test_conversions2 PUBLIC -DTEST_FILE_FOLDER="${TEST_FILE_FOLDER}"

--- a/test/test_conversions1.cpp
+++ b/test/test_conversions1.cpp
@@ -678,4 +678,13 @@ TEST(nat_gas_units, psig)
 
     val = convert(14.6, precise::pressure::psig, precise::pressure::atm, 14.8);
     EXPECT_NEAR(val, 2.0, 0.01);
+
+    val = convert(10, precise_unit(2.0,precise::pressure::psig), precise::pressure::psig);
+    EXPECT_NEAR(val, 20.0, 0.01);
+}
+
+TEST(invalid_conversions, invalid) {
+    using namespace units;
+    double val = detail::extraValidConversions(2.3, precise::m, precise::lb);
+    EXPECT_TRUE(std::isnan(val));
 }

--- a/test/test_conversions1.cpp
+++ b/test/test_conversions1.cpp
@@ -679,11 +679,15 @@ TEST(nat_gas_units, psig)
     val = convert(14.6, precise::pressure::psig, precise::pressure::atm, 14.8);
     EXPECT_NEAR(val, 2.0, 0.01);
 
-    val = convert(10, precise_unit(2.0,precise::pressure::psig), precise::pressure::psig);
+    val = convert(
+        10,
+        precise_unit(2.0, precise::pressure::psig),
+        precise::pressure::psig);
     EXPECT_NEAR(val, 20.0, 0.01);
 }
 
-TEST(invalid_conversions, invalid) {
+TEST(invalid_conversions, invalid)
+{
     using namespace units;
     double val = detail::extraValidConversions(2.3, precise::m, precise::lb);
     EXPECT_TRUE(std::isnan(val));

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -937,3 +937,10 @@ TEST(defaultUnits, singleCharacter)
     EXPECT_EQ(precise::cd, default_unit("J"));
     EXPECT_EQ(precise::K, default_unit("\xC8"));
 }
+
+
+TEST(stringGeneration, test1) {
+    auto res = detail::testing::testCleanUpString(
+        detail::testing::testUnitSequenceGeneration(2100.0, "m^-3"), 0);
+    EXPECT_EQ(res, "2.1L^-1");
+}

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -938,8 +938,8 @@ TEST(defaultUnits, singleCharacter)
     EXPECT_EQ(precise::K, default_unit("\xC8"));
 }
 
-
-TEST(stringGeneration, test1) {
+TEST(stringGeneration, test1)
+{
     auto res = detail::testing::testCleanUpString(
         detail::testing::testUnitSequenceGeneration(2100.0, "m^-3"), 0);
     EXPECT_EQ(res, "2.1L^-1");

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -945,14 +945,13 @@ TEST(stringGeneration, test1)
     EXPECT_EQ(res, "2.1L^-1");
 }
 
-TEST(stringCleanup, test1) {
-    auto res = detail::testing::testCleanUpString(
-        "0.000000045lb", 0);
+TEST(stringCleanup, test1)
+{
+    auto res = detail::testing::testCleanUpString("0.000000045lb", 0);
     EXPECT_EQ(res, "0.000000045lb");
 
-     res = detail::testing::testCleanUpString("0.0000000000000045lb", 0);
+    res = detail::testing::testCleanUpString("0.0000000000000045lb", 0);
     EXPECT_EQ(res, "0.0000000000000045lb");
-
 
     res = detail::testing::testCleanUpString("1.00000000000009lb", 0);
     EXPECT_EQ(res, "1lb");
@@ -969,6 +968,6 @@ TEST(stringCleanup, test1) {
     res = detail::testing::testCleanUpString("1.0000000000000lb", 0);
     EXPECT_EQ(res, "1lb");
 
-     res = detail::testing::testCleanUpString("1.0000000000000", 0);
+    res = detail::testing::testCleanUpString("1.0000000000000", 0);
     EXPECT_EQ(res, "1");
 }

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -944,3 +944,31 @@ TEST(stringGeneration, test1)
         detail::testing::testUnitSequenceGeneration(2100.0, "m^-3"), 0);
     EXPECT_EQ(res, "2.1L^-1");
 }
+
+TEST(stringCleanup, test1) {
+    auto res = detail::testing::testCleanUpString(
+        "0.000000045lb", 0);
+    EXPECT_EQ(res, "0.000000045lb");
+
+     res = detail::testing::testCleanUpString("0.0000000000000045lb", 0);
+    EXPECT_EQ(res, "0.0000000000000045lb");
+
+
+    res = detail::testing::testCleanUpString("1.00000000000009lb", 0);
+    EXPECT_EQ(res, "1lb");
+
+    res = detail::testing::testCleanUpString("1.00000000000019lb", 0);
+    EXPECT_EQ(res, "1.00000000000019lb");
+
+    res = detail::testing::testCleanUpString("1.00000009000009lb", 0);
+    EXPECT_EQ(res, "1.00000009lb");
+
+    res = detail::testing::testCleanUpString("100000009000009lb", 0);
+    EXPECT_EQ(res, "100000009000009lb");
+
+    res = detail::testing::testCleanUpString("1.0000000000000lb", 0);
+    EXPECT_EQ(res, "1lb");
+
+     res = detail::testing::testCleanUpString("1.0000000000000", 0);
+    EXPECT_EQ(res, "1");
+}

--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -27,6 +27,13 @@ else(UNITS_HEADER_ONLY)
                                 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         )
         target_link_libraries(units-static PRIVATE compile_flags_target)
+
+        if (UNITS_ENABLE_TESTS)
+        target_compile_definitions(
+            units-static PUBLIC -DENABLE_UNIT_TESTING=1
+         )
+        endif()
+
         add_library(units::units ALIAS units-static)
         add_library(units::static ALIAS units-static)
         if(UNITS_INSTALL)

--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -28,10 +28,8 @@ else(UNITS_HEADER_ONLY)
         )
         target_link_libraries(units-static PRIVATE compile_flags_target)
 
-        if (UNITS_ENABLE_TESTS)
-        target_compile_definitions(
-            units-static PUBLIC -DENABLE_UNIT_TESTING=1
-         )
+        if(UNITS_ENABLE_TESTS)
+            target_compile_definitions(units-static PUBLIC -DENABLE_UNIT_TESTING=1)
         endif()
 
         add_library(units::units ALIAS units-static)

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -889,14 +889,21 @@ static std::string
 
     if (!propUnitString.empty() && isDigitCharacter(propUnitString.front())) {
         // search for a bunch of zeros in a row
+        std::size_t indexingloc{0};
+        
         auto zloc = propUnitString.find("00000");
-        if (zloc != std::string::npos) {
+        while (zloc != std::string::npos) {
+            indexingloc = zloc + 5;
             auto nloc = propUnitString.find_first_not_of('0', zloc + 5);
             if (nloc != std::string::npos) {
                 if (propUnitString[nloc] != '.') {
-                    if (propUnitString.size() > nloc + 1 &&
-                        !isDigitCharacter(propUnitString[nloc + 1])) {
-                        ++nloc;
+                    if (!isDigitCharacter(propUnitString[nloc])||(propUnitString.size() > nloc + 1 &&
+                        !isDigitCharacter(propUnitString[nloc + 1]))) {
+                       
+                        if (isDigitCharacter(propUnitString[nloc])) {
+                            ++nloc;
+                        }
+                        
                         auto dloc = propUnitString.find_last_of('.', zloc);
 
                         if (dloc != std::string::npos && dloc - nloc > 15) {
@@ -931,12 +938,49 @@ static std::string
                             }
                             if (valid) {
                                 propUnitString.erase(zloc, nloc - zloc);
+                                indexingloc = zloc + 1;
                             }
                         }
                     }
                 }
             } else {
+                auto dloc = propUnitString.find_last_of('.', zloc);
+
+                if (dloc != std::string::npos) {
+                    bool valid = true;
+                    if (dloc == zloc - 1) {
+                        --zloc;
+                        auto ploc = dloc;
+                        valid = false;
+                        while (true) {
+                            if (ploc > 0) {
+                                --ploc;
+                                if (!isDigitCharacter(propUnitString[ploc])) {
+                                    break;
+                                }
+                                if (propUnitString[ploc] != '0') {
+                                    valid = true;
+                                    break;
+                                }
+                            }
+                        }
+                    } else {
+                        auto ploc = dloc + 1;
+                        while (ploc < zloc) {
+                            if (!isDigitCharacter(propUnitString[ploc])) {
+                                valid = false;
+                                break;
+                            }
+                            ++ploc;
+                        }
+                    }
+                    if (valid) {
+                        propUnitString.erase(zloc, std::string::npos);
+                        indexingloc = zloc + 1;
+                    }
+                }
             }
+            zloc = propUnitString.find("00000",indexingloc);
         }
     }
 

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -890,20 +890,20 @@ static std::string
     if (!propUnitString.empty() && isDigitCharacter(propUnitString.front())) {
         // search for a bunch of zeros in a row
         std::size_t indexingloc{0};
-        
+
         auto zloc = propUnitString.find("00000");
         while (zloc != std::string::npos) {
             indexingloc = zloc + 5;
             auto nloc = propUnitString.find_first_not_of('0', zloc + 5);
             if (nloc != std::string::npos) {
                 if (propUnitString[nloc] != '.') {
-                    if (!isDigitCharacter(propUnitString[nloc])||(propUnitString.size() > nloc + 1 &&
-                        !isDigitCharacter(propUnitString[nloc + 1]))) {
-                       
+                    if (!isDigitCharacter(propUnitString[nloc]) ||
+                        (propUnitString.size() > nloc + 1 &&
+                         !isDigitCharacter(propUnitString[nloc + 1]))) {
                         if (isDigitCharacter(propUnitString[nloc])) {
                             ++nloc;
                         }
-                        
+
                         auto dloc = propUnitString.find_last_of('.', zloc);
 
                         if (dloc != std::string::npos && dloc - nloc > 15) {
@@ -980,7 +980,7 @@ static std::string
                     }
                 }
             }
-            zloc = propUnitString.find("00000",indexingloc);
+            zloc = propUnitString.find("00000", indexingloc);
         }
     }
 

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -887,44 +887,42 @@ static std::string
         return propUnitString;
     }
 
-    if (!propUnitString.empty() && isDigitCharacter(propUnitString.front()))
-    {
+    if (!propUnitString.empty() && isDigitCharacter(propUnitString.front())) {
         // search for a bunch of zeros in a row
         auto zloc = propUnitString.find("00000");
-        if (zloc!=std::string::npos) {
+        if (zloc != std::string::npos) {
             auto nloc = propUnitString.find_first_not_of('0', zloc + 5);
-            if (nloc!=std::string::npos) {
-                if (propUnitString[nloc]!='.') {
-                    if (propUnitString.size()>nloc+1&&!isDigitCharacter(propUnitString[nloc+1])) {
+            if (nloc != std::string::npos) {
+                if (propUnitString[nloc] != '.') {
+                    if (propUnitString.size() > nloc + 1 &&
+                        !isDigitCharacter(propUnitString[nloc + 1])) {
                         ++nloc;
                         auto dloc = propUnitString.find_last_of('.', zloc);
-                        
-                        if (dloc != std::string::npos && dloc-nloc>15)
-                        {
+
+                        if (dloc != std::string::npos && dloc - nloc > 15) {
                             bool valid = true;
-                            if (dloc==zloc-1) {
+                            if (dloc == zloc - 1) {
                                 --zloc;
                                 auto ploc = dloc;
                                 valid = false;
                                 while (true) {
-                                    if (ploc>0) {
+                                    if (ploc > 0) {
                                         --ploc;
-                                        if (!isDigitCharacter(propUnitString[ploc]))
-                                        {
+                                        if (!isDigitCharacter(
+                                                propUnitString[ploc])) {
                                             break;
                                         }
-                                        if (propUnitString[ploc]!='0') {
-                                            valid=true;
+                                        if (propUnitString[ploc] != '0') {
+                                            valid = true;
                                             break;
                                         }
                                     }
                                 }
-                            }
-                            else {
-                                
+                            } else {
                                 auto ploc = dloc + 1;
-                                while (ploc<zloc) {
-                                    if (!isDigitCharacter(propUnitString[ploc])) {
+                                while (ploc < zloc) {
+                                    if (!isDigitCharacter(
+                                            propUnitString[ploc])) {
                                         valid = false;
                                         break;
                                     }
@@ -934,13 +932,10 @@ static std::string
                             if (valid) {
                                 propUnitString.erase(zloc, nloc - zloc);
                             }
-                          
                         }
                     }
                 }
-            }
-            else {
-                
+            } else {
             }
         }
     }
@@ -1915,11 +1910,11 @@ namespace detail {
         {
             return generateUnitSequence(mul, test);
         }
-            std::string testCleanUpString(
-                std::string testString, std::uint32_t commodity)
-            {
-                return clean_unit_string(std::move(testString), commodity);
-            }
+        std::string
+            testCleanUpString(std::string testString, std::uint32_t commodity)
+        {
+            return clean_unit_string(std::move(testString), commodity);
+        }
     }  // namespace testing
 }  // namespace detail
 

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -439,9 +439,14 @@ static std::string getMultiplierString(double multiplier, bool numOnly = false)
             return std::string(1, si->second);
         }
     }
+    int X;  // the exponent
+    int P = 18;  // the desired precision
+
+    std::frexp(multiplier, &X);
+
     std::stringstream ss;
-    ss << std::setprecision(18);
-    ss << multiplier;
+
+    ss << std::setprecision(P) << multiplier;
     auto rv = ss.str();
     // modify some improper strings that cause issues later on
     if (rv == "inf") {
@@ -463,7 +468,7 @@ static std::string generateUnitSequence(double mux, std::string seq)
             mux *= 1000.0;
         }
     } else if (seq.compare(0, 4, "m^-3") == 0) {
-        if (mux > 10.0) {
+        if (mux > 100.0) {
             seq.replace(0, 4, "L^-1");
             mux /= 1000.0;
         }
@@ -850,7 +855,7 @@ static void escapeString(std::string& str)
     }
 }
 // clean up the unit string and add a commodity if necessary
-std::string
+static std::string
     clean_unit_string(std::string propUnitString, std::uint32_t commodity)
 {
     using spair = std::tuple<const char*, const char*, int, int>;
@@ -881,11 +886,64 @@ std::string
         !isDigitCharacter(propUnitString.front())) {
         return propUnitString;
     }
-    // TODO(PT)  do some additional number clean up if there is a number in
-    // front
-    // if (!propUnitString.empty() && isDigitCharacter(propUnitString.front()))
-    // {
-    // }
+
+    if (!propUnitString.empty() && isDigitCharacter(propUnitString.front()))
+    {
+        // search for a bunch of zeros in a row
+        auto zloc = propUnitString.find("00000");
+        if (zloc!=std::string::npos) {
+            auto nloc = propUnitString.find_first_not_of('0', zloc + 5);
+            if (nloc!=std::string::npos) {
+                if (propUnitString[nloc]!='.') {
+                    if (propUnitString.size()>nloc+1&&!isDigitCharacter(propUnitString[nloc+1])) {
+                        ++nloc;
+                        auto dloc = propUnitString.find_last_of('.', zloc);
+                        
+                        if (dloc != std::string::npos && dloc-nloc>15)
+                        {
+                            bool valid = true;
+                            if (dloc==zloc-1) {
+                                --zloc;
+                                auto ploc = dloc;
+                                valid = false;
+                                while (true) {
+                                    if (ploc>0) {
+                                        --ploc;
+                                        if (!isDigitCharacter(propUnitString[ploc]))
+                                        {
+                                            break;
+                                        }
+                                        if (propUnitString[ploc]!='0') {
+                                            valid=true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            else {
+                                
+                                auto ploc = dloc + 1;
+                                while (ploc<zloc) {
+                                    if (!isDigitCharacter(propUnitString[ploc])) {
+                                        valid = false;
+                                        break;
+                                    }
+                                    ++ploc;
+                                }
+                            }
+                            if (valid) {
+                                propUnitString.erase(zloc, nloc - zloc);
+                            }
+                          
+                        }
+                    }
+                }
+            }
+            else {
+                
+            }
+        }
+    }
 
     if (commodity != 0) {
         std::string cString = getCommodityName(
@@ -1839,6 +1897,7 @@ static double readNumericalWords(const std::string& ustring, size_t& index)
     return val;
 }
 
+#ifdef ENABLE_UNIT_TESTING
 namespace detail {
     namespace testing {
         // generate a number from a number sequence
@@ -1850,8 +1909,21 @@ namespace detail {
         {
             return readNumericalWords(test, index);
         }
+
+        std::string
+            testUnitSequenceGeneration(double mul, const std::string& test)
+        {
+            return generateUnitSequence(mul, test);
+        }
+            std::string testCleanUpString(
+                std::string testString, std::uint32_t commodity)
+            {
+                return clean_unit_string(std::move(testString), commodity);
+            }
     }  // namespace testing
 }  // namespace detail
+
+#endif
 
 /** Words of SI prefixes
 https://physics.nist.gov/cuu/Units/prefixes.html

--- a/units/units.hpp
+++ b/units/units.hpp
@@ -2057,7 +2057,7 @@ namespace detail {
         std::string
             testUnitSequenceGeneration(double mul, const std::string& test);
 
-         // test the string cleanup
+        // test the string cleanup
         std::string
             testCleanUpString(std::string testString, std::uint32_t commodity);
     }  // namespace testing

--- a/units/units.hpp
+++ b/units/units.hpp
@@ -2044,7 +2044,7 @@ namespace constants {
                                              precise::J* precise::s};
     }  // namespace atomic
 }  // namespace constants
-#define ENABLE_UNIT_TESTING
+
 #ifdef ENABLE_UNIT_TESTING
 namespace detail {
     /// A namespace specifically for unit testing some components

--- a/units/units.hpp
+++ b/units/units.hpp
@@ -2044,7 +2044,8 @@ namespace constants {
                                              precise::J* precise::s};
     }  // namespace atomic
 }  // namespace constants
-
+#define ENABLE_UNIT_TESTING
+#ifdef ENABLE_UNIT_TESTING
 namespace detail {
     /// A namespace specifically for unit testing some components
     namespace testing {
@@ -2052,7 +2053,15 @@ namespace detail {
         double testLeadingNumber(const std::string& test, size_t& index);
         // generate a number from words
         double testNumericalWords(const std::string& test, size_t& index);
+        // test the unit string generation
+        std::string
+            testUnitSequenceGeneration(double mul, const std::string& test);
+
+         // test the string cleanup
+        std::string
+            testCleanUpString(std::string testString, std::uint32_t commodity);
     }  // namespace testing
 }  // namespace detail
+#endif
 
 }  // namespace units


### PR DESCRIPTION
Shorten a few numeric strings that have a bunch of zeros due to double precision resolution