### PR TITLE
Support "As" and Ah" in `unit_from_string`

### DIFF
--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -512,6 +512,8 @@ TEST(stringToUnits, equivalents3)
     EXPECT_EQ(unit_from_string("Ns"), precise::N * precise::s);
     EXPECT_EQ(unit_from_string("N.s"), precise::N * precise::s);
     EXPECT_EQ(unit_from_string("Newton second"), precise::N * precise::s);
+    EXPECT_EQ(unit_from_string("As"), precise::A * precise::s);
+    EXPECT_EQ(unit_from_string("Ah"), precise::A * precise::hr);
     auto u2 = unit_from_string("molcubicfoot");
     EXPECT_FALSE(is_error(u2));
     EXPECT_EQ(u2, precise::mol * precise::ft.pow(3));

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -2599,6 +2599,10 @@ static const smap base_unit_vals{
                                      // separation functions
     {"Nm", precise::N* precise::m},  // this would not pass through to the
                                      // separation functions
+    {"As", precise::A* precise::s},  // this would not pass through to the
+                                     // separation functions
+    {"Ah", precise::A* precise::hr},  // this would not pass through to the
+                                      // separation functions
     {"newton", precise::N},
     {"Pa", precise::Pa},
     {"pa", precise::Pa},


### PR DESCRIPTION
Currently `master` seems to interpret `As` and `Ah` as attoseconds and attohours. For some reasons the case of `A` is ignored (atto should be lowercase `a`?), and not intepreted as `Ampere`.

I copied the approach taken for `Ns` and `Nm`, which apparently ran into the same issue.