### PR TITLE
Main map exposure

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,7 +48,7 @@ else()
         test_unit_strings PUBLIC -DTEST_FILE_FOLDER="${TEST_FILE_FOLDER}"
     )
 
-    target_compile_definitions(test_unit_strings PUBLIC -DENABLE_UNIT_TESTING=1)
+    target_compile_definitions(test_unit_strings PUBLIC -DENABLE_UNIT_TESTING=1 -DENABLE_UNIT_MAP_ACCESS=1)
     target_compile_definitions(test_leadingNumbers PUBLIC -DENABLE_UNIT_TESTING=1)
 
     target_compile_definitions(

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -1036,6 +1036,29 @@ TEST(stringCleanup, test_9strings)
     EXPECT_EQ(res, "10.7*999999999999999999999999lb");
 }
 
+TEST(mapTests, testRoundTrip)
+{
+    const auto& map = detail::getUnitStringMap();
+    for (const auto& val : map) {
+        auto runit = val.second;
+        if (!val.first.empty() && val.first.front() != '*') {
+            std::string str = "1*" + val.first;
+
+            auto strUnit = unit_from_string(str);
+            if (isnan(strUnit)) {
+                EXPECT_TRUE(isnan(runit));
+            } else {
+                EXPECT_EQ(strUnit, runit)
+                    << str << " failed to convert properly";
+            }
+        }
+    }
+}
+
+TEST(mapTests, testRoundTripFromUnit)
+{
+    const auto& map = detail::getUnitNameMap();
+}
 namespace units {
 
 static std::ostream& operator<<(std::ostream& os, const units::precise_unit& u)

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -1039,10 +1039,70 @@ TEST(stringCleanup, test_9strings)
 TEST(mapTests, testRoundTrip)
 {
     const auto& map = detail::getUnitStringMap();
+    int invalidCount = 0;
     for (const auto& val : map) {
         auto runit = val.second;
         if (!val.first.empty() && val.first.front() != '*') {
+            if (is_default(val.second)) {
+                // any multiplier by default units is just the multiplier
+                // which doesn't make sense for this test
+                continue;
+            }
+            if (!is_valid(val.second)) {
+                // this would cause issues as well so not a useful test
+                continue;
+            }
+            if (val.first.find_last_of(' ')!=std::string::npos) {
+                //these are special cases and not useful for testing here
+                continue;
+            }
+            // some specicialized units
+            if (val.second==precise::special::rootHertz) {
+                continue;
+            }
+            if (val.second == precise::special::ASD) {
+                continue;
+            }
+            if (val.first.compare(0,2,"50")==0) {
+                //some specialized tissue culture units
+                continue;
+            }
+            if (val.first.find(")_")!=std::string::npos) {
+                continue;
+            }
             std::string str = "1*" + val.first;
+
+            auto strUnit = unit_from_string(str);
+            if (isnan(runit)) {
+                EXPECT_TRUE(isnan(strUnit));
+                if (!isnan(strUnit)) {
+                    strUnit = unit_from_string(str);
+                    ++invalidCount;
+                }
+            } else {
+                if (strUnit != runit) {
+                    if (val.second.has_same_base(precise::rad)) {
+                        continue;
+                    }
+                    strUnit = unit_from_string(str);
+                    EXPECT_EQ(strUnit, runit)
+                        << str << " failed to convert properly";
+                    ++invalidCount;
+                }
+            }
+        }
+    }
+    EXPECT_EQ(invalidCount, 0);
+}
+
+TEST(mapTests, testRoundTripFromUnit)
+{
+    const auto& map = detail::getUnitNameMap();
+    for (const auto& val : map) {
+        auto runit = val.first;
+        std::string uname(val.second);
+        if (!uname.empty() && uname.front() != '*') {
+            std::string str = "1*" + uname;
 
             auto strUnit = unit_from_string(str);
             if (isnan(strUnit)) {
@@ -1050,14 +1110,12 @@ TEST(mapTests, testRoundTrip)
             } else {
                 EXPECT_EQ(strUnit, runit)
                     << str << " failed to convert properly";
+                if (strUnit!=runit) {
+                    strUnit = unit_from_string(str);
+                }
             }
         }
     }
-}
-
-TEST(mapTests, testRoundTripFromUnit)
-{
-    const auto& map = detail::getUnitNameMap();
 }
 namespace units {
 

--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -29,7 +29,7 @@ else(UNITS_HEADER_ONLY)
         target_link_libraries(units-static PRIVATE compile_flags_target)
 
         if(UNITS_ENABLE_TESTS)
-            target_compile_definitions(units-static PUBLIC -DENABLE_UNIT_TESTING=1)
+            target_compile_definitions(units-static PUBLIC -DENABLE_UNIT_TESTING=1 -DENABLE_UNIT_MAP_ACCESS=1)
         endif()
 
         add_library(units::units ALIAS units-static)

--- a/units/commodities.cpp
+++ b/units/commodities.cpp
@@ -266,6 +266,8 @@ namespace commodities {
         {"vox", voxel},
         {"pix", pixel},
         {"dot", pixel},
+        {"error",errors},
+        {"errors", errors},
     };
 }  // namespace commodities
 static constexpr std::uint32_t Ac{54059}; /* a prime */

--- a/units/unit_definitions.hpp
+++ b/units/unit_definitions.hpp
@@ -110,6 +110,7 @@ namespace commodities {
         // computer
         pixel = 516115414,
         voxel = 516115415,
+        errors = 516115418,
     };
 }  // namespace commodities
 

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -6912,4 +6912,18 @@ precise_unit default_unit(std::string unit_type)
     return precise::invalid;
 }
 
+
+#ifdef ENABLE_UNIT_MAP_ACCESS
+namespace detail {
+    const std::unordered_map<std::string, precise_unit>& getUnitStringMap() 
+    {
+        return base_unit_vals;
+    }
+    const std::unordered_map<unit, const char*>& getUnitNameMap()
+    {
+        return base_unit_names;
+    }
+}  // namespace detail
+#endif
+
 }  // namespace units

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -2417,11 +2417,17 @@ static const smap base_unit_vals{
          std::numeric_limits<double>::quiet_NaN())},
     {"sNaN", precise::nan},
     {"1.#SNAN", precise::nan},
+    {"#SNAN", precise::nan},
     {"1.#QNAN",
      precise_unit(
          detail::unit_data(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
          std::numeric_limits<double>::quiet_NaN())},
+    {"#QNAN",
+     precise_unit(
+         detail::unit_data(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+         std::numeric_limits<double>::quiet_NaN())},
     {"1.#IND", precise::nan},
+    {"#IND", precise::nan},
     {"0.1", precise_unit(0.1, precise::one)},
     {".1", precise_unit(0.1, precise::one)},
     {"deci", precise_unit(0.1, precise::one)},
@@ -3248,6 +3254,9 @@ static const smap base_unit_vals{
     {"ua", precise::distance::au_old},
     {"$", precise::currency},
     {"dollar", precise::currency},
+    {"euro", precise::currency},
+    {"yen", precise::currency},
+    {"ruble", precise::currency},
     {"currency", precise::currency},
     {u8"\u00A2", precise_unit(0.01, precise::currency)},  // cent symbol
     {"\xA2", precise_unit(0.01, precise::currency)},  // cent symbol latin-1
@@ -3258,9 +3267,7 @@ static const smap base_unit_vals{
     {u8"\u00A5", precise::currency},  // Yen sign
     {"\xA5", precise::currency},  // Yen sign latin-1
     {u8"\u0080", precise::currency},  // Euro sign
-    {u8"\u20AC", precise::currency},  // Euro sign
     {"\x80", precise::currency},  // Euro sign extended ascii
-    {u8"\u20BD", precise::currency},  // Ruble sign
     {"count", precise::count},
     {"unit", precise::count},
     {"pair", precise_unit(2.0, precise::count)},
@@ -3992,7 +3999,6 @@ static const smap base_unit_vals{
     {"scruple_ap", precise::apothecaries::scruple},
     {u8"\u2108", precise::apothecaries::scruple},
     {"dr_ap", precise::apothecaries::drachm},
-    {u8"\u01B7", precise::apothecaries::drachm},
     {u8"\u0292", precise::apothecaries::drachm},
     {"dram_ap", precise::apothecaries::drachm},
     {"[DR_AP]", precise::apothecaries::drachm},
@@ -4373,8 +4379,10 @@ static const smap base_unit_vals{
     {"B(10nV)", precise::log::B_10nV},
     {"bel10nanovolt", precise::log::B_10nV},
     {"dB[10.nV]", precise::log::dB_10nV},
+    {"dB[10*nV]", precise::log::dB_10nV},
     {"decibel10nanovolt", precise::log::B_10nV},
     {"B[10*NV]", precise::log::B_10nV},
+    {"B[10*nV]", precise::log::B_10nV},
     {"DB[10*NV]", precise::log::dB_10nV},
     {"B[W]", precise::log::B_W},
     {"B(W)", precise::log::B_W},
@@ -4607,7 +4615,20 @@ static precise_unit commoditizedUnit(
     ++ccindex;
     auto start = ccindex;
     segmentcheck(unit_string, '}', ccindex);
-    auto hcode = getCommodity(unit_string.substr(start, ccindex - start - 1));
+    if (ccindex - start == 2) {
+        // there are a couple units that might look like commodities
+        if (unit_string[start] == '#') {
+            index = ccindex;
+            return actUnit * count;
+        }
+    }
+    std::string commodStr = unit_string.substr(start, ccindex - start - 1);
+    if (commodStr == "cells")
+    {
+        index = ccindex;
+        return actUnit* precise_unit(1.0, precise::count, commodities::cell);
+    }
+    auto hcode = getCommodity(std::move(commodStr));
     index = ccindex;
     return {1.0, actUnit, hcode};
 }
@@ -5243,7 +5264,7 @@ static void htmlCodeReplacement(std::string& unit_string)
 /// in the basic ascii set)
 static bool unicodeReplacement(std::string& unit_string)
 {
-    static UNITS_CPP14_CONSTEXPR_OBJECT std::array<ckpair, 45>
+    static UNITS_CPP14_CONSTEXPR_OBJECT std::array<ckpair, 48>
         ucodeReplacements{{
             ckpair{u8"\u00d7", "*"},
             ckpair{u8"\u00f7", "/"},  // division sign
@@ -5276,6 +5297,10 @@ static bool unicodeReplacement(std::string& unit_string)
             ckpair{u8"\u2154", "(2/3)"},  // (2/3) fraction
             ckpair{u8"\u215B", "0.125"},  // (1/8) fraction
             ckpair{u8"\u215F", "1/"},  // 1/ numerator operator
+            ckpair{u8"\u20AC", "\x80"}, //euro sign to extended ascii
+            ckpair{u8"\u20BD", "ruble"},  // Ruble sign
+            ckpair{u8"\u01B7",
+                   "dr_ap"},  // drachm symbol
             ckpair{"-\xb3", "^(-3)"},
             ckpair{"-\xb9", "^(-1)"},
             ckpair{"-\xb2", "^(-2)"},
@@ -6009,14 +6034,14 @@ static precise_unit unit_from_string_internal(
     if (unit_string.empty()) {
         return precise::one;
     }
-    if (unit_string.size() > 1024) {  // there is no reason whatsoever that a
-                                      // unit string would be longer than 1024
-                                      // characters
+    if (unit_string.size() > 1024) {
+        // there is no reason whatsoever that a unit string would be longer than
+        // 1024 characters
         return precise::invalid;
     }
     precise_unit retunit;
-    if ((match_flags & case_insensitive) ==
-        0) {  // if not a ci matching process just do a quick scan first
+    if ((match_flags & case_insensitive) == 0) {
+        // if not a ci matching process just do a quick scan first
         retunit = get_unit(unit_string);
         if (is_valid(retunit)) {
             return retunit;
@@ -6110,6 +6135,10 @@ static precise_unit unit_from_string_internal(
                         retunit = precise::one;
                     }
                 } else {
+                    if (is_valid(retunit))
+                    {
+                        return front_unit * retunit;
+                    }
                     auto commodity = getCommodity(unit_string.substr(index));
                     front_unit.commodity(commodity);
                     return front_unit;

--- a/units/units.hpp
+++ b/units/units.hpp
@@ -12,6 +12,11 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <type_traits>
 #include <utility>
 
+
+#ifdef ENABLE_UNIT_MAP_ACCESS
+#include <unordered_map>
+#endif
+
 #if __cplusplus >= 201402L || (defined(_MSC_VER) && _MSC_VER >= 1910)
 #define UNITS_CPP14_CONSTEXPR_OBJECT constexpr
 #define UNITS_CPP14_CONSTEXPR_METHOD constexpr
@@ -2062,6 +2067,13 @@ namespace detail {
             testCleanUpString(std::string testString, std::uint32_t commodity);
     }  // namespace testing
 }  // namespace detail
+#endif
+
+#ifdef ENABLE_UNIT_MAP_ACCESS
+namespace detail {
+    const std::unordered_map<std::string, precise_unit>& getUnitStringMap();
+    const std::unordered_map<unit, const char*>& getUnitNameMap();
+}
 #endif
 
 }  // namespace units


### PR DESCRIPTION
address Issue #109 
Adding some mechanisms to expose the internal maps of string conversions for use in GUI's or other purposes. 

A project would have to define ENABLE_UNIT_MAP_ACCESS

to give access to two function that grab the conversion maps

```cpp
#ifdef ENABLE_UNIT_MAP_ACCESS
namespace detail {
    const std::unordered_map<std::string, precise_unit>& getUnitStringMap();
    const std::unordered_map<unit, const char*>& getUnitNameMap();
}
#endif
``` 