### PR TITLE
add some check strings for common compound units with si prefixes

### DIFF
--- a/test/files/SI_Units.csv
+++ b/test/files/SI_Units.csv
@@ -1,0 +1,43 @@
+time,second,s,
+time,minute,min,60.s
+time,hour,h, 60.min
+time,day,d,24.h
+frequency,hertz,Hz,ÿÿs^-1
+signaling rate,baud,Bd,ÿÿs^-1
+length,meter,m,
+volume,liter,L,ÿÿdm^3
+plane angle,radian,rad,
+solid angle,steradian,sr,ÿÿrad^2
+plane angle,revolution,r,6.283185307179586.rad
+plane angle,degree,o,2.777777777777778e-3.r
+information capacity,bit,bit,
+information capacity,"byte, octet",B,8.bit
+mass,gram,g,
+mass,ton,t,ÿÿMg
+mass,unified atomic mass unit,u,1.660538782e-27.kg
+amount of substance,mole,mol,
+catalytic activity,katal,kat,ÿÿmol/s
+thermodynamic temperature,kelvin,K,
+temperature,degree Celsius,oC,
+luminous intensity,candela,cd,
+luminous flux,lumen,lm,ÿÿcd.sr
+illuminance,lux,lx,ÿÿlm/m^2
+force,newton,N,ÿÿm.kg.s^-2
+"pressure, stress",pascal,Pa,ÿÿN/m^2
+"energy, work, heat",joule,J,ÿÿN.m
+energy,electronvolt,eV,=ÿ1.602176487e-19.J
+"power, radiant flux",watt,W,ÿÿJ/s
+logarithm of power ratio,neper,Np,
+logarithm of power ratio,decibel,dB,=*0.1151293.Np
+electric current,ampere,A,
+electric charge,coulomb,C,ÿÿs.A
+"electric potential, EMF",volt,V,ÿÿW/A
+capacitance,farad,F,ÿÿC/V
+electric resistance,ohm,Ohm,ÿÿV/A
+electric conductance,siemens,S,ÿÿA/V
+magnetic flux,weber,Wb,ÿÿV.s
+magnetic flux density,tesla,T,ÿÿWb/m^2
+inductance,henry,H,ÿÿWb/A
+radionuclide activity,becquerel,Bq,ÿÿs^-1
+absorbed dose energy,gray,Gy,ÿÿm^2.s^-2
+dose equivalent,sievert,Sv,ÿÿm^2.s^-2

--- a/test/files/si_examples.csv
+++ b/test/files/si_examples.csv
@@ -1,0 +1,36 @@
+area,square meter,m^2
+volume,cubic meter,m^3
+"speed, velocity",meter per second,m/s
+acceleration,meter per second squared,m/s^2
+wave number,reciprocal meter,m^-1
+mass density (density),kilogram per cubic meter,kg/m^3
+specific volume,cubic meter per kilogram,m^3/kg
+current density,ampere per square meter,A/m^2
+magnetic field strength,ampere per meter,A/m
+concentration,mole per cubic meter,mol/m^3
+luminance,candela per square meter,cd/m^2
+angular velocity,radian per second,rad/s
+angular acceleration,radian per second squared,rad/s^2
+dynamic viscosity,pascal second,Pa.s
+moment of force,newton meter,N.m
+surface tension,newton per meter,N/m
+heat flux density,watt per square meter,W/m^2
+radiant intensity,watt per steradian,W/sr
+radiance,watt per square meter steradian,W/(m^2.sr)
+"heat capacity, entropy",joule per kelvin,J/K
+specific heat or entropy,joule per kilogram kelvin,J/(kg.K)
+specific energy,joule per kilogram,J/kg
+thermal conductivity,watt per meter kelvin,W/(m.K)
+energy density,joule per cubic meter,J/m^3
+electric field strength,volt per meter,V/m
+electric charge density,coulomb per cubic meter,C/m^3
+electric flux density,coulomb per square meter,C/m^2
+permittivity,farad per meter,F/m
+permeability,henry per meter,H/m
+molar energy,joule per mole,J/mol
+molar entropy or heat,joule per mole kelvin,J/(mol.K)
+exposure (x and g rays),coulomb per kilogram,C/kg
+rotational speed,revolution per minute,r/min
+catalytic concentration,katal per cubic meter,kat/m^3
+data rate,mebibit per second,Mib/s
+noise voltage density,nanovolt per root hertz,nV/Hz^(1/2)

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -212,16 +212,16 @@ TEST(unitStrings, charge)
     // A * s = C
     EXPECT_EQ(to_string(precise::A * precise::s), "C");
     // A * h = 3600 C, better use A * h
-    EXPECT_EQ(to_string(precise::A * precise::hr), "Ahr");
-    EXPECT_EQ(to_string(precise::femto * precise::A * precise::hr), "fAhr");
-    EXPECT_EQ(to_string(precise::pico * precise::A * precise::hr), "pAhr");
-    EXPECT_EQ(to_string(precise::nano * precise::A * precise::hr), "nAhr");
-    EXPECT_EQ(to_string(precise::micro * precise::A * precise::hr), "uAhr");
-    EXPECT_EQ(to_string(precise::milli * precise::A * precise::hr), "mAhr");
-    EXPECT_EQ(to_string(precise::kilo * precise::A * precise::hr), "kAhr");
-    EXPECT_EQ(to_string(precise::mega * precise::A * precise::hr), "MAhr");
-    EXPECT_EQ(to_string(precise::giga * precise::A * precise::hr), "GAhr");
-    EXPECT_EQ(to_string(precise::tera * precise::A * precise::hr), "TAhr");
+    EXPECT_EQ(to_string(precise::A * precise::hr), "Ah");
+    EXPECT_EQ(to_string(precise::femto * precise::A * precise::hr), "fAh");
+    EXPECT_EQ(to_string(precise::pico * precise::A * precise::hr), "pAh");
+    EXPECT_EQ(to_string(precise::nano * precise::A * precise::hr), "nAh");
+    EXPECT_EQ(to_string(precise::micro * precise::A * precise::hr), "uAh");
+    EXPECT_EQ(to_string(precise::milli * precise::A * precise::hr), "mAh");
+    EXPECT_EQ(to_string(precise::kilo * precise::A * precise::hr), "kAh");
+    EXPECT_EQ(to_string(precise::mega * precise::A * precise::hr), "MAh");
+    EXPECT_EQ(to_string(precise::giga * precise::A * precise::hr), "GAh");
+    EXPECT_EQ(to_string(precise::tera * precise::A * precise::hr), "TAh");
 }
 
 TEST(unitStrings, electronVolt)
@@ -234,6 +234,15 @@ TEST(unitStrings, electronVolt)
     EXPECT_EQ(to_string(precise::mega * precise::energy::eV), "MeV");
     EXPECT_EQ(to_string(precise::giga * precise::energy::eV), "GeV");
     EXPECT_EQ(to_string(precise::tera * precise::energy::eV), "TeV");
+}
+
+TEST(unitStrings, watthours)
+{
+    EXPECT_EQ(to_string(precise::A * precise::s), "C");
+    EXPECT_EQ(to_string(precise::W * precise::hr), "Wh");
+    EXPECT_EQ(to_string(precise::kilo * precise::W * precise::h), "kWh");
+    EXPECT_EQ(to_string(precise::mega * precise::W * precise::h), "MWh");
+    EXPECT_EQ(to_string(precise::giga * precise::W * precise::h), "GWh");
 }
 
 TEST(unitStrings, customUnits)
@@ -542,7 +551,8 @@ TEST(stringToUnits, equivalents3)
     EXPECT_EQ(unit_from_string("N.s"), precise::N * precise::s);
     EXPECT_EQ(unit_from_string("Newton second"), precise::N * precise::s);
     EXPECT_EQ(unit_from_string("As"), precise::A * precise::s);
-    EXPECT_EQ(unit_from_string("Ah"), precise::A * precise::hr);
+    EXPECT_EQ(unit_from_string("Ah"), precise::A * precise::h);
+    EXPECT_EQ(unit_from_string("Ahr"), precise::A * precise::h);
     auto u2 = unit_from_string("molcubicfoot");
     EXPECT_FALSE(is_error(u2));
     EXPECT_EQ(u2, precise::mol * precise::ft.pow(3));

--- a/units/unit_definitions.hpp
+++ b/units/unit_definitions.hpp
@@ -349,6 +349,7 @@ namespace precise {
         constexpr precise_unit ms(0.001, s);
         constexpr precise_unit ns(1e-9, s);
         constexpr precise_unit hr(60.0, min);
+        constexpr precise_unit h(60.0, min);
         constexpr precise_unit day(24.0, hr);
         constexpr precise_unit week(7.0, day);
         constexpr precise_unit yr(8760.0, hr);  // median calendar year;
@@ -369,6 +370,7 @@ namespace precise {
     constexpr precise_unit ms = time::ms;
     constexpr precise_unit ns = time::ns;
     constexpr precise_unit hr = time::hr;
+    constexpr precise_unit h = time::h;
     constexpr precise_unit yr = time::yr;
     constexpr precise_unit day = time::day;
 
@@ -537,7 +539,7 @@ namespace precise {
         constexpr precise_unit league(4828.032, m);
         constexpr precise_unit mile{5280.0, foot};
         constexpr precise_unit nautical_mile{6080, foot};
-        constexpr precise_unit knot = nautical_mile / hr;
+        constexpr precise_unit knot = nautical_mile / h;
         constexpr precise_unit acre{4840.0, yard.pow(2)};
 
         // area
@@ -583,7 +585,7 @@ namespace precise {
         constexpr precise_unit fathom(2.0, i::yard);
         constexpr precise_unit cable(120, fathom);
         constexpr precise_unit mile(1.852, km);
-        constexpr precise_unit knot = mile / hr;
+        constexpr precise_unit knot = mile / h;
         constexpr precise_unit league(3.0, mile);
     }  // namespace nautical
 
@@ -778,7 +780,7 @@ namespace precise {
     constexpr precise_unit hp = power::hpI;
 
     // Speed units
-    constexpr precise_unit mph(mile / hr);
+    constexpr precise_unit mph(mile / h);
     constexpr precise_unit mps(m / s);
 
     /// Energy units
@@ -806,12 +808,12 @@ namespace precise {
                                                        // btu
         constexpr precise_unit btu_iso{1055.06, J};  // rounded btu_it
         constexpr precise_unit quad(1055.05585262, J);
-        constexpr precise_unit tonc(12000.0, btu_th / hr);
+        constexpr precise_unit tonc(12000.0, btu_th / h);
 
         constexpr precise_unit therm_us(100000.0, btu_59);
         constexpr precise_unit therm_br(105505585.257, J);
         constexpr precise_unit therm_ec(100000, btu_iso);
-        constexpr precise_unit EER(btu_th / W / hr);  // Energy efficiency ratio
+        constexpr precise_unit EER(btu_th / W / h);  // Energy efficiency ratio
         constexpr precise_unit SG(lb / ft.pow(3) * pu);  // Specific gravity
 
         constexpr precise_unit ton_tnt{4.184, precise::giga* precise::J};
@@ -1558,6 +1560,7 @@ constexpr unit min = unit_cast(precise::min);
 constexpr unit ms = unit_cast(precise::ms);
 constexpr unit ns = unit_cast(precise::ns);
 constexpr unit hr = unit_cast(precise::hr);
+constexpr unit h = unit_cast(precise::h);
 constexpr unit yr = unit_cast(precise::yr);
 // angle measure
 constexpr unit deg = unit_cast(precise::deg);

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -145,16 +145,7 @@ static const umap base_unit_names{
     {kg, "kg"},
     {mol, "mol"},
     {A, "A"},
-    {A * hr, "Ahr"},
-    {femto * A * hr, "fAhr"},
-    {pico * A * hr, "pAhr"},
-    {nano * A * hr, "nAhr"},
-    {micro * A * hr, "uAhr"},
-    {milli * A * hr, "mAhr"},
-    {kilo * A * hr, "kAhr"},
-    {mega * A * hr, "MAhr"},
-    {giga * A * hr, "GAhr"},
-    {tera * A * hr, "TAhr"},
+    {A * h, "Ah"},
     {V, "V"},
     {s, "s"},
     // this is so Gs doesn't get used which can cause issues
@@ -213,7 +204,7 @@ static const umap base_unit_names{
     {min, "min"},
     {ms, "ms"},
     {ns, "ns"},
-    {hr, "hr"},
+    {h, "h"},
     {unit_cast(precise::time::day), "day"},
     {unit_cast(precise::time::week), "week"},
     {unit_cast(precise::time::yr), "yr"},
@@ -277,13 +268,6 @@ static const umap base_unit_names{
     {hp, "hp"},
     {mph, "mph"},
     {unit_cast(precise::energy::eV), "eV"},
-    {unit_cast(precise::nano * precise::energy::eV), "neV"},
-    {unit_cast(precise::micro * precise::energy::eV), "ueV"},
-    {unit_cast(precise::milli * precise::energy::eV), "meV"},
-    {unit_cast(precise::kilo * precise::energy::eV), "keV"},
-    {unit_cast(precise::mega * precise::energy::eV), "MeV"},
-    {unit_cast(precise::giga * precise::energy::eV), "GeV"},
-    {unit_cast(precise::tera * precise::energy::eV), "TeV"},
     {kcal, "kcal"},
     {btu, "btu"},
     {unit_cast(precise::other::CFM), "CFM"},
@@ -355,6 +339,12 @@ static UNITS_CPP14_CONSTEXPR_OBJECT std::array<ustr, 22> testUnits{
      ustr{precise::MW, "MW"},
      ustr{precise::s.pow(2), "s^2"},
      ustr{precise::count, "item"}}};
+
+// units to divide into tests to explore common multiplier units
+static UNITS_CPP14_CONSTEXPR_OBJECT std::array<ustr, 3> siTestUnits{
+    {ustr{precise::h * precise::A, "Ah"},
+     ustr{precise::energy::eV, "eV"},
+     ustr{precise::W * precise::h, "Wh"}}};
 
 // complex units used to reduce unit complexity
 static UNITS_CPP14_CONSTEXPR_OBJECT std::array<ustr, 4> creduceUnits{
@@ -1348,12 +1338,30 @@ static std::string
         }
         return cxstr;
     }
+    /** check for a few units with odd numbers that allow SI prefixes*/
 
     if (un.unit_type_count() == 1) {
         return generateUnitSequence(un.multiplier(), generateRawUnitString(un));
     }
     if (un.unit_type_count() == 2 && un.multiplier() == 1) {
         return generateUnitSequence(1.0, generateRawUnitString(un));
+    }
+    /** check for a few units with odd numbers that allow SI prefixes*/
+    for (auto& siU : siTestUnits)
+    {
+        auto nu = un / siU.first;
+        if (nu.unit_type_count() == 0)
+        {
+            auto mult = getMultiplierString(nu.multiplier());
+            if (mult.empty())
+            {
+                return siU.second;
+            }
+            if (!isNumericalStartCharacter(mult.front()))
+            {
+                return mult + siU.second;
+            }
+        }
     }
     // lets try converting to pure base unit
     auto bunit = unit(un.base_units());
@@ -2625,6 +2633,8 @@ static const smap base_unit_vals{
     {"As", precise::A* precise::s},  // this would not pass through to the
                                      // separation functions
     {"Ah", precise::A* precise::hr},  // this would not pass through to the
+                                      // separation functions
+    {"Ahr", precise::A* precise::hr},  // this would not pass through to the
                                       // separation functions
     {"newton", precise::N},
     {"Pa", precise::Pa},
@@ -6023,6 +6033,71 @@ static precise_unit unit_to_the_power_of(
     return precise::defunit;
 }
 
+static precise_unit
+    checkSIprefix(const std::string& unit_string, std::uint32_t match_flags)
+{
+    bool threeAgain{false};
+    if (unit_string.size() >= 3) {
+        if (unit_string[1]=='A') {
+            threeAgain = true;
+        }
+        else {
+        auto mux = getPrefixMultiplier2Char(unit_string[0], unit_string[1]);
+        if (mux != 0.0) {
+            auto ustring = unit_string.substr(2);
+            if (ustring == "B") {
+                return {mux, precise::data::byte};
+            }
+            if (ustring == "b") {
+                return {mux, precise::data::bit};
+            }
+            auto retunit = unit_quick_match(ustring, match_flags);
+            if (is_valid(retunit)) {
+                return {mux, retunit};
+            }
+        }
+        }
+    }
+    if (unit_string.size() >= 2) {
+        auto c = unit_string.front();
+        if (c == 'N' && ((match_flags & case_insensitive) != 0)) {
+            c = 'n';
+        }
+        auto mux = getPrefixMultiplier(c);
+        if (mux != 0.0) {
+            auto ustring = unit_string.substr(1);
+            if (ustring == "B") {
+                return {mux, precise::data::byte};
+            }
+            if (ustring == "b") {
+                return {mux, precise::data::bit};
+            }
+            auto retunit = unit_quick_match(ustring, match_flags);
+            if (!is_error(retunit)) {
+                return {mux, retunit};
+            }
+        }
+    }
+    if (threeAgain)
+    {
+        auto mux = getPrefixMultiplier2Char(unit_string[0], unit_string[1]);
+        if (mux != 0.0) {
+            auto ustring = unit_string.substr(2);
+            if (ustring == "B") {
+                return {mux, precise::data::byte};
+            }
+            if (ustring == "b") {
+                return {mux, precise::data::bit};
+            }
+            auto retunit = unit_quick_match(ustring, match_flags);
+            if (is_valid(retunit)) {
+                return {mux, retunit};
+            }
+        }
+    }
+    return precise::invalid;
+}
+
 precise_unit
     unit_from_string(std::string unit_string, std::uint32_t match_flags)
 {
@@ -6161,7 +6236,10 @@ static precise_unit unit_from_string_internal(
             return front_unit * retunit;
         }
     }
-
+    retunit=checkSIprefix(unit_string,match_flags);
+    if (is_valid(retunit)) {
+        return retunit;
+    }
     auto sep = findOperatorSep(unit_string, "*/");
     if (sep != std::string::npos) {
         precise_unit a_unit;
@@ -6241,42 +6319,7 @@ static precise_unit unit_from_string_internal(
         unit_string.find('{') != std::string::npos) {
         return commoditizedUnit(unit_string, match_flags);
     }
-    if (unit_string.size() >= 3) {
-        auto mux = getPrefixMultiplier2Char(unit_string[0], unit_string[1]);
-        if (mux != 0.0) {
-            ustring = unit_string.substr(2);
-            if (ustring == "B") {
-                return {mux, precise::data::byte};
-            }
-            if (ustring == "b") {
-                return {mux, precise::data::bit};
-            }
-            retunit = unit_quick_match(ustring, match_flags);
-            if (is_valid(retunit)) {
-                return {mux, retunit};
-            }
-        }
-    }
-    if (unit_string.size() >= 2) {
-        auto c = unit_string.front();
-        if (c == 'N' && ((match_flags & case_insensitive) != 0)) {
-            c = 'n';
-        }
-        auto mux = getPrefixMultiplier(c);
-        if (mux != 0.0) {
-            ustring = unit_string.substr(1);
-            if (ustring == "B") {
-                return {mux, precise::data::byte};
-            }
-            if (ustring == "b") {
-                return {mux, precise::data::bit};
-            }
-            retunit = unit_quick_match(ustring, match_flags);
-            if (!is_error(retunit)) {
-                return {mux, retunit};
-            }
-        }
-    }
+    
     // don't do any further steps if recursion is not available
     if ((match_flags & no_recursion) != 0) {
         return unit_quick_match(unit_string, match_flags);


### PR DESCRIPTION
 - add string conversions for better support of 'eV', 'Ah', and 'Wh', to allow SI prefixes on them cleanly.  
 - change the default 'hr' output to 'h'  to match SI standards, 
 - add some files for future SI string tests.  
