### PR TITLE
C++20 required flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,15 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     include(compiler_flags)
 endif()
 
+# deal with breaking changes in C++20 with u8 strings
+if(CMAKE_CXX_STANDARD GREATER 19 OR UNITS_CXX_STANDARD GREATER 19)
+    if(MSVC)
+        target_compile_options(compile_flags_target INTERFACE /Zc:char8_t-)
+    else(MSVC)
+        target_compile_options(compile_flags_target INTERFACE -fno-char8_t)
+    endif()
+endif()
+
 if(NOT UNITS_HEADER_ONLY)
     if(BUILD_SHARED_LIBS)
         option(UNITS_BUILD_STATIC_LIBRARY

--- a/config/compiler_flags.cmake
+++ b/config/compiler_flags.cmake
@@ -116,9 +116,6 @@ endif()
 # Extra definitions for visual studio
 # -------------------------------------------------------------
 if(MSVC)
-    if(CMAKE_CXX_STANDARD GREATER 19 OR UNITS_CXX_STANDARD GREATER 19)
-        target_compile_options(compile_flags_target INTERFACE /Zc:char8_t-)
-    endif()
     target_compile_options(
         compile_flags_target INTERFACE -D_CRT_SECURE_NO_WARNINGS
                                        -D_SCL_SECURE_NO_WARNINGS
@@ -130,9 +127,6 @@ if(MSVC)
     endif(${PROJECT_NAME}_ENABLE_EXTRA_COMPILER_WARNINGS)
     target_compile_options(compile_flags_target INTERFACE -D_WIN32_WINNT=0x0601)
 else(MSVC)
-    if(CMAKE_CXX_STANDARD GREATER 19 OR UNITS_CXX_STANDARD GREATER 19)
-        target_compile_options(compile_flags_target INTERFACE -fno-char8_t)
-    endif()
     option(USE_LIBCXX "Use Libc++ vs as opposed to the default" OFF)
     mark_as_advanced(USE_LIBCXX)
     # this is a global option on all parts


### PR DESCRIPTION
Some C++20 flags were not be propagated properly for compiling the library if adding the library via add_subdirectory.