### PR TITLE
Si prefix formatting

### DIFF
--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -234,6 +234,10 @@ TEST(unitStrings, electronVolt)
     EXPECT_EQ(to_string(precise::mega * precise::energy::eV), "MeV");
     EXPECT_EQ(to_string(precise::giga * precise::energy::eV), "GeV");
     EXPECT_EQ(to_string(precise::tera * precise::energy::eV), "TeV");
+
+    auto str =
+        to_string(precise::count / (precise::milli * precise::energy::eV));
+    EXPECT_EQ(str, "count/meV");
 }
 
 TEST(unitStrings, watthours)
@@ -243,6 +247,14 @@ TEST(unitStrings, watthours)
     EXPECT_EQ(to_string(precise::kilo * precise::W * precise::h), "kWh");
     EXPECT_EQ(to_string(precise::mega * precise::W * precise::h), "MWh");
     EXPECT_EQ(to_string(precise::giga * precise::W * precise::h), "GWh");
+
+    auto str = to_string(
+        precise::currency / (precise::giga * precise::W * precise::h));
+    EXPECT_EQ(str, "$/GWh");
+
+    str = to_string(
+        precise::m * (precise::giga * precise::W * precise::h));
+    EXPECT_EQ(str, "GWh*m");
 }
 
 TEST(unitStrings, customUnits)

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -1369,7 +1369,7 @@ static std::string
                 rstring.push_back('*');
                 rstring.append(to_string_internal(nu, match_flags));
                 return rstring;
-            };
+            }
 
             if (!isNumericalStartCharacter(mult.front())) {
                 nu = precise_unit{nu.base_units(), 1.0};
@@ -1410,7 +1410,7 @@ static std::string
                 rstring.push_back('/');
                 rstring.append(siU.second);
                 return rstring;
-            };
+            }
 
             if (!isNumericalStartCharacter(mult.front())) {
                 nu = precise_unit{nu.base_units(), 1.0};

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -231,7 +231,7 @@ static const umap base_unit_names{
     {unit_cast(precise::special::ASD), "ASD"},
     {unit_cast(precise::special::rootHertz), "rootHertz"},
     {currency, "$"},
-    {count, "item"},
+    {count, "count"},
     {ratio, ""},
     {error, "ERROR"},
     {defunit, "defunit"},
@@ -1362,6 +1362,66 @@ static std::string
                 return rstring;
             }
         }
+        if (nu.unit_type_count() == 1) {
+            auto mult = getMultiplierString(nu.multiplier());
+            if (mult.empty()) {
+                std::string rstring{siU.second};
+                rstring.push_back('*');
+                rstring.append(to_string_internal(nu, match_flags));
+                return rstring;
+            };
+
+            if (!isNumericalStartCharacter(mult.front())) {
+                nu = precise_unit{nu.base_units(), 1.0};
+                std::string rstring = mult + siU.second;
+                rstring.push_back('*');
+                rstring.append(to_string_internal(nu, match_flags));
+                return rstring;
+            }
+        }
+            nu = un * siU.first;
+            if (nu.unit_type_count() == 0) {
+                auto mult = getMultiplierString(1.0/nu.multiplier());
+                if (mult.empty()) {
+                    std::string rstring;
+                    addUnitFlagStrings(nu, rstring);
+                    if (rstring.empty())
+                    {
+                        rstring.push_back('1');
+                    }
+                    rstring.push_back('/');
+                    rstring.append(siU.second);
+                    return rstring;
+                }
+                if (!isNumericalStartCharacter(mult.front())) {
+                    std::string rstring;
+                    addUnitFlagStrings(nu, rstring);
+                    if (rstring.empty()) {
+                        rstring.push_back('1');
+                    }
+                    rstring.push_back('/');
+                    rstring.append(mult + siU.second);
+                    return rstring;
+                }
+            }
+            if (nu.unit_type_count() == 1) {
+                auto mult = getMultiplierString(1.0/nu.multiplier());
+                if (mult.empty()) {
+                    std::string rstring{to_string_internal(nu, match_flags)};
+                    rstring.push_back('/');
+                    rstring.append(siU.second);
+                    return rstring;
+                };
+
+                if (!isNumericalStartCharacter(mult.front())) {
+                    nu = precise_unit{nu.base_units(), 1.0};
+                    std::string rstring{to_string_internal(nu, match_flags)};
+                    rstring.push_back('/');
+                    rstring.append(mult);
+                    rstring.append(siU.second);
+                    return rstring;
+                }
+            }
     }
     // lets try converting to pure base unit
     auto bunit = unit(un.base_units());


### PR DESCRIPTION
add some specialized string formatting for aggregate units with si prefixes
specifically related to units 'eV', 'Ah', and 'Wh'  

Fixes PR #121