### PR TITLE
Add helpers to determine of operations overflow base unit exponents

### DIFF
--- a/test/test_unit_ops.cpp
+++ b/test/test_unit_ops.cpp
@@ -1031,6 +1031,8 @@ TEST(UnitUtilTest, times_overflows)
     EXPECT_FALSE(times_overflows(im4, im4));
     EXPECT_TRUE(times_overflows(im4, im5));  // underflow
     EXPECT_TRUE(times_overflows(im5, im4));  // underflow
+
+    EXPECT_TRUE(times_overflows(count, count));
 }
 
 TEST(UnitUtilTest, divides_overflows)

--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -6,7 +6,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 set(units_source_files units.cpp x12_conv.cpp r20_conv.cpp commodities.cpp)
 
-set(units_header_files units.hpp units_decl.hpp unit_definitions.hpp)
+set(units_header_files units.hpp units_decl.hpp unit_definitions.hpp units_util.hpp)
 
 if(UNITS_HEADER_ONLY)
     add_library(units-header-only INTERFACE)

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -20,6 +20,24 @@ namespace detail {
     */
     class unit_data {
       public:
+        /** Number of bits used for encoding base unit exponents */
+        struct bits {
+            static constexpr int32_t meter = 4;
+            static constexpr int32_t second = 4;  // 8
+            static constexpr int32_t kilogram = 3;
+            static constexpr int32_t ampere = 3;
+            static constexpr int32_t candela = 2;  // 16
+            static constexpr int32_t kelvin = 3;
+            static constexpr int32_t mole = 2;
+            static constexpr int32_t radians = 3;  // 24
+            static constexpr int32_t currency = 2;
+            static constexpr int32_t count = 2;  // 28
+            static constexpr int32_t per_unit = 1;
+            static constexpr int32_t i_flag = 1;  // 30
+            static constexpr int32_t e_flag = 1;
+            static constexpr int32_t equation = 1;  // 32
+        };
+
         // construct from powers
         constexpr unit_data(
             int meters,
@@ -295,20 +313,20 @@ namespace detail {
         }
 
         // needs to be defined for the full 32 bits
-        signed int meter_ : 4;
-        signed int second_ : 4;  // 8
-        signed int kilogram_ : 3;
-        signed int ampere_ : 3;
-        signed int candela_ : 2;  // 16
-        signed int kelvin_ : 3;
-        signed int mole_ : 2;
-        signed int radians_ : 3;  // 24
-        signed int currency_ : 2;
-        signed int count_ : 2;  // 28
-        unsigned int per_unit_ : 1U;
-        unsigned int i_flag_ : 1U;  // 30
-        unsigned int e_flag_ : 1U;  //
-        unsigned int equation_ : 1U;  // 32
+        signed int meter_ : bits::meter;
+        signed int second_ : bits::second;
+        signed int kilogram_ : bits::kilogram;
+        signed int ampere_ : bits::ampere;
+        signed int candela_ : bits::candela;
+        signed int kelvin_ : bits::kelvin;
+        signed int mole_ : bits::mole;
+        signed int radians_ : bits::radians;
+        signed int currency_ : bits::currency;
+        signed int count_ : bits::count;
+        unsigned int per_unit_ : bits::per_unit;
+        unsigned int i_flag_ : bits::i_flag;
+        unsigned int e_flag_ : bits::e_flag;
+        unsigned int equation_ : bits::equation;
     };
     // We want this to be exactly 4 bytes by design
     static_assert(

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -38,8 +38,8 @@ namespace detail {
             Equation
         };
         // Cannot use std::array since no constexpr support in macOS clang
-        static constexpr int32_t bits[14] =
-            {4, 4, 3, 3, 2, 3, 2, 3, 2, 2, 1, 1, 1, 1};  // NOLINT
+        static constexpr int32_t bits[14] =  // NOLINT
+            {4, 4, 3, 3, 2, 3, 2, 3, 2, 2, 1, 1, 1, 1};
 
         // construct from powers
         constexpr unit_data(

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -37,8 +37,8 @@ namespace detail {
             EFlag,
             Equation
         };
-        static constexpr std::array<int32_t, 14>
-            bits{4, 4, 3, 3, 2, 3, 2, 3, 2, 2, 1, 1, 1, 1};
+        static constexpr std::array<int32_t, 14> bits{
+            {4, 4, 3, 3, 2, 3, 2, 3, 2, 2, 1, 1, 1, 1}};
 
         // construct from powers
         constexpr unit_data(

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -21,22 +21,24 @@ namespace detail {
     class unit_data {
       public:
         /** Number of bits used for encoding base unit exponents */
-        struct bits {
-            static constexpr int32_t meter = 4;
-            static constexpr int32_t second = 4;  // 8
-            static constexpr int32_t kilogram = 3;
-            static constexpr int32_t ampere = 3;
-            static constexpr int32_t candela = 2;  // 16
-            static constexpr int32_t kelvin = 3;
-            static constexpr int32_t mole = 2;
-            static constexpr int32_t radians = 3;  // 24
-            static constexpr int32_t currency = 2;
-            static constexpr int32_t count = 2;  // 28
-            static constexpr int32_t per_unit = 1;
-            static constexpr int32_t i_flag = 1;  // 30
-            static constexpr int32_t e_flag = 1;
-            static constexpr int32_t equation = 1;  // 32
+        enum base {
+            Meter,
+            Second,
+            Kilogram,
+            Ampere,
+            Candela,
+            Kelvin,
+            Mole,
+            Radians,
+            Currency,
+            Count,
+            PerUnit,
+            IFlag,
+            EFlag,
+            Equation
         };
+        static constexpr std::array<int32_t, 14>
+            bits{4, 4, 3, 3, 2, 3, 2, 3, 2, 2, 1, 1, 1, 1};
 
         // construct from powers
         constexpr unit_data(
@@ -313,20 +315,20 @@ namespace detail {
         }
 
         // needs to be defined for the full 32 bits
-        signed int meter_ : bits::meter;
-        signed int second_ : bits::second;
-        signed int kilogram_ : bits::kilogram;
-        signed int ampere_ : bits::ampere;
-        signed int candela_ : bits::candela;
-        signed int kelvin_ : bits::kelvin;
-        signed int mole_ : bits::mole;
-        signed int radians_ : bits::radians;
-        signed int currency_ : bits::currency;
-        signed int count_ : bits::count;
-        unsigned int per_unit_ : bits::per_unit;
-        unsigned int i_flag_ : bits::i_flag;
-        unsigned int e_flag_ : bits::e_flag;
-        unsigned int equation_ : bits::equation;
+        signed int meter_ : bits[Meter];
+        signed int second_ : bits[Second];  // 8
+        signed int kilogram_ : bits[Kilogram];
+        signed int ampere_ : bits[Ampere];
+        signed int candela_ : bits[Candela];  // 16
+        signed int kelvin_ : bits[Kelvin];
+        signed int mole_ : bits[Mole];
+        signed int radians_ : bits[Radians];  // 24
+        signed int currency_ : bits[Currency];
+        signed int count_ : bits[Count];  // 28
+        unsigned int per_unit_ : bits[PerUnit];
+        unsigned int i_flag_ : bits[IFlag];  // 30
+        unsigned int e_flag_ : bits[EFlag];
+        unsigned int equation_ : bits[Equation];  // 32
     };
     // We want this to be exactly 4 bytes by design
     static_assert(

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -37,8 +37,8 @@ namespace detail {
             EFlag,
             Equation
         };
-        static constexpr std::array<int32_t, 14> bits{
-            {4, 4, 3, 3, 2, 3, 2, 3, 2, 2, 1, 1, 1, 1}};
+        static constexpr int32_t bits[14] =
+            {4, 4, 3, 3, 2, 3, 2, 3, 2, 2, 1, 1, 1, 1};
 
         // construct from powers
         constexpr unit_data(

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -37,8 +37,9 @@ namespace detail {
             EFlag,
             Equation
         };
+        // Cannot use std::array since no constexpr support in macOS clang
         static constexpr int32_t bits[14] =
-            {4, 4, 3, 3, 2, 3, 2, 3, 2, 2, 1, 1, 1, 1};
+            {4, 4, 3, 3, 2, 3, 2, 3, 2, 2, 1, 1, 1, 1};  // NOLINT
 
         // construct from powers
         constexpr unit_data(

--- a/units/units_util.hpp
+++ b/units/units_util.hpp
@@ -1,0 +1,113 @@
+/*
+Copyright (c) 2019-2021,
+Lawrence Livermore National Security, LLC;
+See the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+*/
+#pragma once
+
+#include "units_decl.hpp"
+
+namespace units {
+namespace detail {
+
+    template<int Bits>
+    struct bitfield {
+        static constexpr int32_t min = -(static_cast<int32_t>(1U << Bits) / 2);
+        static constexpr int32_t max = static_cast<int32_t>(1U << Bits) / 2 - 1;
+        template<class T>
+        static constexpr bool plus_overflows(const T& a, const T& b)
+        {
+            return ((b > 0) && (a > max - b)) || ((b < 0) && (a < min - b));
+        }
+        template<class T>
+        static constexpr bool minus_overflows(const T& a, const T& b)
+        {
+            return ((b < 0) && (a > max + b)) || ((b > 0) && (a < min + b));
+        }
+        template<class T>
+        static constexpr bool times_overflows(const T& a, const T& b)
+        {
+            return ((a == -1) && (b == min)) || ((b == -1) && (a == min)) ||
+                (a > max / b) || ((a < min / b));
+        }
+    };
+
+    constexpr bool times_overflows(const unit_data& a, const unit_data& b)
+    {
+        return (
+            bitfield<4>::plus_overflows(a.meter(), b.meter()) ||
+            bitfield<4>::plus_overflows(a.second(), b.second()) ||
+            bitfield<3>::plus_overflows(a.kg(), b.kg()) ||
+            bitfield<3>::plus_overflows(a.ampere(), b.ampere()) ||
+            bitfield<2>::plus_overflows(a.candela(), b.candela()) ||
+            bitfield<3>::plus_overflows(a.kelvin(), b.kelvin()) ||
+            bitfield<2>::plus_overflows(a.mole(), b.mole()) ||
+            bitfield<3>::plus_overflows(a.radian(), b.radian()) ||
+            bitfield<2>::plus_overflows(a.currency(), b.currency()) ||
+            bitfield<2>::plus_overflows(a.count(), b.count()));
+    }
+
+    constexpr bool divides_overflows(const unit_data& a, const unit_data& b)
+    {
+        return (
+            bitfield<4>::minus_overflows(a.meter(), b.meter()) ||
+            bitfield<4>::minus_overflows(a.second(), b.second()) ||
+            bitfield<3>::minus_overflows(a.kg(), b.kg()) ||
+            bitfield<3>::minus_overflows(a.ampere(), b.ampere()) ||
+            bitfield<2>::minus_overflows(a.candela(), b.candela()) ||
+            bitfield<3>::minus_overflows(a.kelvin(), b.kelvin()) ||
+            bitfield<2>::minus_overflows(a.mole(), b.mole()) ||
+            bitfield<3>::minus_overflows(a.radian(), b.radian()) ||
+            bitfield<2>::minus_overflows(a.currency(), b.currency()) ||
+            bitfield<2>::minus_overflows(a.count(), b.count()));
+    }
+
+    constexpr bool inv_overflows(const unit_data& a)
+    {
+        return divides_overflows(
+            unit_data{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, a);
+    }
+
+    constexpr bool pow_overflows(const unit_data& a, const int power)
+    {
+        return (
+            bitfield<4>::times_overflows(a.meter(), power) ||
+            bitfield<4>::times_overflows(a.second(), power) ||
+            bitfield<3>::times_overflows(a.kg(), power) ||
+            bitfield<3>::times_overflows(a.ampere(), power) ||
+            bitfield<2>::times_overflows(a.candela(), power) ||
+            bitfield<3>::times_overflows(a.kelvin(), power) ||
+            bitfield<2>::times_overflows(a.mole(), power) ||
+            bitfield<3>::times_overflows(a.radian(), power) ||
+            bitfield<2>::times_overflows(a.currency(), power) ||
+            bitfield<2>::times_overflows(a.count(), power));
+    }
+
+}  // namespace detail
+
+template<class T1, class T2>
+constexpr bool times_overflows(const T1& a, const T2& b)
+{
+    return times_overflows(a.base_units(), b.base_units());
+}
+
+template<class T1, class T2>
+constexpr bool divides_overflows(const T1& a, const T2& b)
+{
+    return divides_overflows(a.base_units(), b.base_units());
+}
+
+template<class T>
+constexpr bool inv_overflows(const T& a)
+{
+    return inv_overflows(a.base_units());
+}
+
+template<class T>
+constexpr bool pow_overflows(const T& a, const int power)
+{
+    return pow_overflows(a.base_units(), power);
+}
+
+}  // namespace units


### PR DESCRIPTION
Inspired from suggestion by @phlptp in #127 to potentially add a `checked_multiply`:

- Add helpers to determine if an operation on `unit_data` would overflow or underflow.
- I chose this approach since this way it can be `constexpr`, rather than a `checked_multiply` which would need to raise an exception or handle errors in a different way. I suppose one could instead return an error/invalid unit from `checked_multiply`?
- Added in new header file, since these helper are probably not required by many users, to keep the main header small.
- I am not so happy with some of the repeated code, but could not come up with a briefer (C++11-compatible) way. Hard-coding the number of bits here in addition to in `unit_data` feels wrong an error prone. Can those sizes be accessed somehow? Should I add a `constexpr static` `unit_data::nbit_meter`, `nbit_second`, ... and use these throughout?