### PR TITLE
Add export macros to ensure symbols are visible

### DIFF
--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -30,6 +30,7 @@ else(UNITS_HEADER_ONLY)
     if(UNITS_BUILD_STATIC_LIBRARY)
         add_library(units-static STATIC ${units_source_files} ${units_header_files})
         generate_export_header(units-static BASE_NAME units)
+        target_compile_definitions(units-static PUBLIC UNITS_EXPORT_HEADER)
         target_include_directories(
             units-static PUBLIC $<BUILD_INTERFACE:${UNITS_SOURCE_DIR}>
                                 $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
@@ -66,6 +67,7 @@ else(UNITS_HEADER_ONLY)
     if(UNITS_BUILD_SHARED_LIBRARY)
         add_library(units-shared SHARED ${units_source_files} ${units_header_files})
         generate_export_header(units-shared BASE_NAME units)
+        target_compile_definitions(units-shared PUBLIC UNITS_EXPORT_HEADER)
         target_include_directories(
             units-shared PUBLIC $<BUILD_INTERFACE:${UNITS_SOURCE_DIR}>
                                 $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -8,6 +8,8 @@ set(units_source_files units.cpp x12_conv.cpp r20_conv.cpp commodities.cpp)
 
 set(units_header_files units.hpp units_decl.hpp unit_definitions.hpp units_util.hpp)
 
+include(GenerateExportHeader)
+
 if(UNITS_HEADER_ONLY)
     add_library(units-header-only INTERFACE)
     target_include_directories(
@@ -27,8 +29,10 @@ if(UNITS_HEADER_ONLY)
 else(UNITS_HEADER_ONLY)
     if(UNITS_BUILD_STATIC_LIBRARY)
         add_library(units-static STATIC ${units_source_files} ${units_header_files})
+        generate_export_header(units-static BASE_NAME units)
         target_include_directories(
             units-static PUBLIC $<BUILD_INTERFACE:${UNITS_SOURCE_DIR}>
+                                $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
                                 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         )
         target_link_libraries(units-static PRIVATE compile_flags_target)
@@ -61,8 +65,10 @@ else(UNITS_HEADER_ONLY)
 
     if(UNITS_BUILD_SHARED_LIBRARY)
         add_library(units-shared SHARED ${units_source_files} ${units_header_files})
+        generate_export_header(units-shared BASE_NAME units)
         target_include_directories(
             units-shared PUBLIC $<BUILD_INTERFACE:${UNITS_SOURCE_DIR}>
+                                $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
                                 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         )
         target_link_libraries(units-shared PRIVATE compile_flags_target)

--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -29,8 +29,6 @@ if(UNITS_HEADER_ONLY)
 else(UNITS_HEADER_ONLY)
     if(UNITS_BUILD_STATIC_LIBRARY)
         add_library(units-static STATIC ${units_source_files} ${units_header_files})
-        generate_export_header(units-static BASE_NAME units)
-        target_compile_definitions(units-static PUBLIC UNITS_EXPORT_HEADER)
         target_include_directories(
             units-static PUBLIC $<BUILD_INTERFACE:${UNITS_SOURCE_DIR}>
                                 $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/units/units.hpp
+++ b/units/units.hpp
@@ -6,6 +6,7 @@ SPDX-License-Identifier: BSD-3-Clause
 */
 #pragma once
 #include "unit_definitions.hpp"
+#include "units_export.h"
 
 #include <cmath>
 #include <string>
@@ -1820,7 +1821,7 @@ enum unit_conversion_flags : std::uint32_t {
         (1U << 31U),  //!< don't do some code and sequence replacements
 };
 /// Generate a string representation of the unit
-std::string
+UNITS_EXPORT std::string
     to_string(const precise_unit& units, std::uint32_t match_flags = 0U);
 
 /// Generate a string representation of the unit
@@ -1837,7 +1838,7 @@ process somewhat
 @return a precise unit corresponding to the string if no match was found the
 unit will be an error unit
 */
-precise_unit
+UNITS_EXPORT precise_unit
     unit_from_string(std::string unit_string, std::uint32_t match_flags = 0U);
 
 /** Generate a unit object from a string representation of it
@@ -1869,7 +1870,7 @@ process somewhat
 @return a precise unit corresponding to the string if no match was found the
 unit will be an error unit
     */
-precise_measurement measurement_from_string(
+UNITS_EXPORT precise_measurement measurement_from_string(
     std::string measurement_string,
     std::uint32_t match_flags = 0U);
 
@@ -1898,22 +1899,22 @@ process somewhat
 @return a precise unit corresponding to the string if no match was found the
 unit will be an error unit
 */
-uncertain_measurement uncertain_measurement_from_string(
+UNITS_EXPORT uncertain_measurement uncertain_measurement_from_string(
     const std::string& measurement_string,
     std::uint32_t match_flags = 0U);
 
 /// Convert a precise measurement to a string (with some extra decimal digits
 /// displayed)
-std::string to_string(
+UNITS_EXPORT std::string to_string(
     const precise_measurement& measure,
     std::uint32_t match_flags = 0U);
 
 /// Convert a measurement to a string
-std::string
+UNITS_EXPORT std::string
     to_string(const measurement& measure, std::uint32_t match_flags = 0U);
 
 /// Convert an uncertain measurement to a string
-std::string to_string(
+UNITS_EXPORT std::string to_string(
     const uncertain_measurement& measure,
     std::uint32_t match_flags = 0U);
 

--- a/units/units.hpp
+++ b/units/units.hpp
@@ -6,7 +6,6 @@ SPDX-License-Identifier: BSD-3-Clause
 */
 #pragma once
 #include "unit_definitions.hpp"
-#include "units_export.h"
 
 #include <cmath>
 #include <string>

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -5,6 +5,7 @@ See the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
 #pragma once
+#include "units_export.h"
 
 #include <cmath>
 #include <cstdint>  // for std::uint32_t
@@ -997,9 +998,9 @@ inline constexpr precise_unit pow(const precise_unit& u, int power)
 #ifndef UNITS_HEADER_ONLY
 
 /// take the root of a unit to some power
-unit root(const unit& u, int power);
+UNITS_EXPORT unit root(const unit& u, int power);
 
-precise_unit root(const precise_unit& u, int power);
+UNITS_EXPORT precise_unit root(const precise_unit& u, int power);
 
 inline unit sqrt(const unit& u)
 {

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -5,7 +5,12 @@ See the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
 #pragma once
+
+#ifdef UNITS_EXPORT_HEADER
 #include "units_export.h"
+#else
+#define UNITS_EXPORT
+#endif
 
 #include <cmath>
 #include <cstdint>  // for std::uint32_t


### PR DESCRIPTION
When using `units` as a shared library, dependent project that set default symbol visibility to hidden (default on Windows) will get errors about missing symbols since currently `units` is not defining exported symbols.

This PR uses `generate_export_header` for this purpose. I have added the required macro in some key relevant places, but I have likely missed more.