### PR TITLE
Fix pow_overflows not handling 0 and negative powers correctly

### DIFF
--- a/test/test_unit_ops.cpp
+++ b/test/test_unit_ops.cpp
@@ -1077,6 +1077,9 @@ TEST(UnitUtilTest, inv_overflows)
 
 TEST(UnitUtilTest, pow_overflows)
 {
+    EXPECT_FALSE(pow_overflows(m, -1));
+    EXPECT_FALSE(pow_overflows(m, 0));
+    EXPECT_FALSE(pow_overflows(m, 1));
     EXPECT_FALSE(pow_overflows(m, 2));
     EXPECT_FALSE(pow_overflows(m, 4));
     EXPECT_FALSE(pow_overflows(m, 7));

--- a/units/units_util.hpp
+++ b/units/units_util.hpp
@@ -30,8 +30,7 @@ namespace detail {
         template<class T>
         static constexpr bool times_overflows(const T& a, const T& b)
         {
-            return ((a == -1) && (b == min)) || ((b == -1) && (a == min)) ||
-                (a > max / b) || ((a < min / b));
+            return (a * b < min) || (a * b > max);
         }
     };
 


### PR DESCRIPTION
What I had implemented in my previous PR did not work for powers 0 and negative powers. Added unit test now.

The new implementation is simpler because it assumes that the exponent
does not overflow `int`, but in practice this should not be an issue,
and the better clarity can avoid the bug.