### PR TITLE
Fix namespace config

### DIFF
--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -43,7 +43,7 @@ else(UNITS_HEADER_ONLY)
         endif()
         if(UNITS_NAMESPACE)
             target_compile_definitions(
-                units-static INTERFACE -DUNITS_NAMESPACE=${UNITS_NAMESPACE}
+                units-static PUBLIC -DUNITS_NAMESPACE=${UNITS_NAMESPACE}
             )
         endif()
         add_library(units::units ALIAS units-static)
@@ -78,7 +78,7 @@ else(UNITS_HEADER_ONLY)
         add_library(units::shared ALIAS units-shared)
         if(UNITS_NAMESPACE)
             target_compile_definitions(
-                units-shared INTERFACE -DUNITS_NAMESPACE=${UNITS_NAMESPACE}
+                units-shared PUBLIC -DUNITS_NAMESPACE=${UNITS_NAMESPACE}
             )
         endif()
         if(UNITS_INSTALL)
@@ -101,7 +101,7 @@ else(UNITS_HEADER_ONLY)
         add_library(units::object ALIAS units-object)
         if(UNITS_NAMESPACE)
             target_compile_definitions(
-                units-object INTERFACE -DUNITS_NAMESPACE=${UNITS_NAMESPACE}
+                units-object PUBLIC -DUNITS_NAMESPACE=${UNITS_NAMESPACE}
             )
         endif()
     endif(UNITS_BUILD_OBJECT_LIBRARY)

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -389,8 +389,8 @@ namespace detail {
 namespace std {
 /// Hash function for unit_data
 template<>
-struct hash<units::detail::unit_data> {
-    size_t operator()(const units::detail::unit_data& x) const noexcept
+struct hash<UNITS_NAMESPACE::detail::unit_data> {
+    size_t operator()(const UNITS_NAMESPACE::detail::unit_data& x) const noexcept
     {
         unsigned int val;
         std::memcpy(&val, &x, sizeof(val));
@@ -1030,19 +1030,19 @@ static_assert(
 /// in unordered_map
 namespace std {
 template<>
-struct hash<units::unit> {
-    size_t operator()(const units::unit& x) const
+struct hash<UNITS_NAMESPACE::unit> {
+    size_t operator()(const UNITS_NAMESPACE::unit& x) const
     {
-        return hash<units::detail::unit_data>()(x.base_units()) ^
+        return hash<UNITS_NAMESPACE::detail::unit_data>()(x.base_units()) ^
             hash<float>()(x.cround());
     }
 };
 
 template<>
-struct hash<units::precise_unit> {
-    size_t operator()(const units::precise_unit& x) const
+struct hash<UNITS_NAMESPACE::precise_unit> {
+    size_t operator()(const UNITS_NAMESPACE::precise_unit& x) const
     {
-        return hash<units::detail::unit_data>()(x.base_units()) ^
+        return hash<UNITS_NAMESPACE::detail::unit_data>()(x.base_units()) ^
             hash<double>()(x.cround());
     }
 };


### PR DESCRIPTION
I had two small problems with what was added in #136:

- Fix namespace macro when specializing hash.
- `target_compile_definitions` with `INTERFACE` didn't work, had to change to `PUBLIC`. I am not sure which is correct and why, but as it is now in `master` I could not get it to work.