### PR TITLE
Fix hash function for 64 bit units base

### DIFF
--- a/test/test_unit_ops.cpp
+++ b/test/test_unit_ops.cpp
@@ -380,6 +380,13 @@ TEST(preciseUnitOps, Hash)
     EXPECT_EQ(h1, h2);
 }
 
+TEST(preciseUnitOps, Hash_covers_full_unit_data_width)
+{
+    auto h1 = std::hash<precise_unit>()(precise::m);
+    auto h2 = std::hash<precise_unit>()(precise::m * precise::count);
+    EXPECT_NE(h1, h2);
+}
+
 TEST(preciseUnitOps, Inv)
 {
     EXPECT_EQ(precise::m.inv(), precise::one / precise::m);

--- a/units/units_decl.hpp
+++ b/units/units_decl.hpp
@@ -407,9 +407,9 @@ struct hash<UNITS_NAMESPACE::detail::unit_data> {
     size_t operator()(const UNITS_NAMESPACE::detail::unit_data& x) const
         noexcept
     {
-        unsigned int val;
+        UNITS_BASE_TYPE val;
         std::memcpy(&val, &x, sizeof(val));
-        return hash<unsigned int>()(val);
+        return hash<UNITS_BASE_TYPE>()(val);
     }
 };
 }  // namespace std


### PR DESCRIPTION
With `-DUNITS_BASE_TYPE=int64_t` the hash function only hashed the first 32 bit of `unit_data`. This led to identical hashes for different units.

See added unit test, which should fail before the fix put always passed for 32 bit `unit_data` width.

Fixes scipp/scipp#1829.