### PR TITLE
powers on units should be disallowed unless using large base type units

### DIFF
--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -257,6 +257,14 @@ TEST(unitString, bigpowers)
         EXPECT_EQ(sp, unit_from_string(spstr));
     }
 }
+
+TEST(unitString, wrapping) {
+    std::string const mol_m3_str("mol/m^3666");
+    unit const mol_m3_unit(units::mol / units::m.pow(3));
+    auto fstr = unit_from_string(mol_m3_str);
+    EXPECT_NE(fstr,mol_m3_unit);
+}
+
 TEST(unitStrings, crazyunits)
 {
     unit cz{detail::unit_data(1, 2, 3, 1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0)};

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -5477,8 +5477,7 @@ static void ciConversion(std::string& unit_string)
     }
 }
 static bool checkExponentOperations(
-    const std::string& unit_string,
-    std::uint32_t match_flags)
+    const std::string& unit_string)
 {
     // check all power operations
     auto cx = unit_string.find_first_of('^');
@@ -5609,7 +5608,7 @@ static bool checkValidUnitString(
                     break;
             }
         }
-        if (!checkExponentOperations(unit_string, match_flags)) {
+        if (!checkExponentOperations(unit_string)) {
             return false;
         }
     }


### PR DESCRIPTION
This PR will address #151.  

It disallows powers on units greater than 9 or <-9 on units unless the UNITS_BASE_TYPE is set to an 8 byte type. 