### PR TITLE
One letter units

### DIFF
--- a/test/fuzz_issue_tests.cpp
+++ b/test/fuzz_issue_tests.cpp
@@ -258,7 +258,7 @@ INSTANTIATE_TEST_SUITE_P(rtripFiles, rtripProblems, ::testing::Range(1, 35));
 
 TEST(fuzzFailures, rtripSingleProblems)
 {
-    auto cdata = loadFailureFile("rtrip_fail", 22);
+    auto cdata = loadFailureFile("rtrip_fail", 21);
     auto u1 = unit_from_string(cdata);
     if (!is_error(u1)) {
         auto str = to_string(u1);

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -1396,7 +1396,7 @@ TEST(mapTests, two_by_one)
     std::vector<std::pair<std::string, precise_unit>> twocharunits;
     std::vector<std::pair<std::string, precise_unit>> onecharunits;
     for (const auto& val : map) {
-        if (val.first.size()==2) {
+        if (val.first.size() == 2) {
             if (val.first.front() > 0 && std::isalpha(val.first.front()) != 0) {
                 if (is_valid(val.second)) {
                     twocharunits.push_back(val);
@@ -1416,6 +1416,11 @@ TEST(mapTests, two_by_one)
     }
 
     for (const auto &twochar:twocharunits) {
+        if (twochar.first == "mo" || twochar.first == "mO") {
+            // month has some expected patterns which will cause problems in
+            // this test
+            continue;
+        }
         for (const auto &onechar:onecharunits) {
             std::string ustring = twochar.first + ' ' + onechar.first;
             auto unit = twochar.second * onechar.second;

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -1388,6 +1388,37 @@ TEST(mapTests, testRoundTripFromUnit)
         }
     }
 }
+
+// test combinations of 2 character units string and one character unit strings for misinterpretation
+TEST(mapTests, two_by_one)
+{
+    const auto& map = detail::getUnitStringMap();
+    std::vector<std::pair<std::string, precise_unit>> twocharunits;
+    std::vector<std::pair<std::string, precise_unit>> onecharunits;
+    for (const auto& val : map) {
+        if (val.first.size()==2) {
+            if (val.first.front() > 0 && std::isalpha(val.first.front()) != 0) {
+                twocharunits.push_back(val);
+            }
+            
+        }
+        if (val.first.size() == 1) {
+            if (val.first.front() > 0 && std::isalpha(val.first.front()) != 0) {
+                onecharunits.push_back(val);
+            }
+           
+        }
+    }
+
+    for (const auto &twochar:twocharunits) {
+        for (const auto &onechar:onecharunits) {
+            std::string ustring = twochar.first + ' ' + onechar.first;
+            auto unit = twochar.second * onechar.second;
+            EXPECT_EQ(unit_from_string(ustring), unit)
+                << ustring << " does not produce equivalent unit";
+        }
+    }
+}
 #endif
 
 namespace units {

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -1398,13 +1398,18 @@ TEST(mapTests, two_by_one)
     for (const auto& val : map) {
         if (val.first.size()==2) {
             if (val.first.front() > 0 && std::isalpha(val.first.front()) != 0) {
-                twocharunits.push_back(val);
+                if (is_valid(val.second)) {
+                    twocharunits.push_back(val);
+                }
+                
             }
             
         }
         if (val.first.size() == 1) {
             if (val.first.front() > 0 && std::isalpha(val.first.front()) != 0) {
-                onecharunits.push_back(val);
+                if (is_valid(val.second)) {
+                    onecharunits.push_back(val);
+                }
             }
            
         }

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -3835,6 +3835,12 @@ static bool cleanUnitString(std::string& unit_string, std::uint32_t match_flags)
         unit_string.clear();
         return true;
     }
+    if (c != 0)
+    {
+        unit_string.erase(0, c);
+        c = unit_string.find_first_not_of(spchar);
+        changed = true;
+    }
     if (unit_string[c] == '/') {
         unit_string.insert(c, 1, '1');
         changed = true;
@@ -3849,7 +3855,7 @@ static bool cleanUnitString(std::string& unit_string, std::uint32_t match_flags)
                 changed = true;
             }
         }
-        if (unit_string.find_first_of(" \t\n\r") != std::string::npos)
+        if (c != std::string::npos)
         {
             //deal with some particular string with a space in them
             

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -3689,7 +3689,7 @@ static void checkPowerOf10(std::string& unit_string)
 static std::string shortStringReplacement(char U)
 {
     static const std::unordered_map<char, std::string> singleCharUnitStrings{
-        {'m', "meter"}, {'s', "second"}, {'S', "siemens"},     {' l', "liter"},
+        {'m', "meter"}, {'s', "second"}, {'S', "siemens"},     {'l', "liter"},
         {'g', "gram"},  {'b', "barn"},   {'r', "revolutions"}, {'V', "volt"},
         {'F', "farad"}, {'y', "year"},   {'p', "poise"},        {'K', "kelvin"},
         {'a', "are"},   {'N', "newton"}, {'d', "day"},        {'B', "byte"},

--- a/units/units_conversion_maps.hpp
+++ b/units/units_conversion_maps.hpp
@@ -201,7 +201,7 @@ UNITS_CPP14_CONSTEXPR_OBJECT std::array<std::pair<unit, const char*>, 180>
 /// definitions for the default units for specific types of measurmeents
 UNITS_CPP14_CONSTEXPR_OBJECT std::array<
     std::pair<const char*, precise_unit>,
-    1100>
+    1106>
     defined_unit_strings_si{{
         {"", precise::defunit},
         {"[]", precise::defunit},
@@ -1045,12 +1045,15 @@ UNITS_CPP14_CONSTEXPR_OBJECT std::array<
         {"stdatmosphere", precise::pressure::atm},
         {"stdatm", precise::pressure::atm},
         {"mmHg", precise::pressure::mmHg},
+        {"mm_Hg", precise::pressure::mmHg},
         {"mm[Hg]", precise::pressure::mmHg},
         {"MM[HG]", precise::pressure::mmHg},
         {"cmHg", precise::ten* precise::pressure::mmHg},
+        {"cm_Hg", precise::ten* precise::pressure::mmHg},
         {"cm[Hg]", precise::ten* precise::pressure::mmHg},
         {"CM[HG]", precise::ten* precise::pressure::mmHg},
         {"mHg", precise::kilo* precise::pressure::mmHg},
+        {"m_Hg", precise::kilo* precise::pressure::mmHg},
         {"m*Hg", precise::kilo* precise::pressure::mmHg},
         {"m[Hg]", precise::kilo* precise::pressure::mmHg},
         {"M[HG]", precise::kilo* precise::pressure::mmHg},
@@ -1063,12 +1066,15 @@ UNITS_CPP14_CONSTEXPR_OBJECT std::array<
         {"meterofmercurycolumn", precise::kilo* precise::pressure::mmHg},
         {"metersofmercurycolumn", precise::kilo* precise::pressure::mmHg},
         {"mmH2O", precise::pressure::mmH2O},
+        {"mm_H2O", precise::pressure::mmH2O},
         {"mm[H2O]", precise::pressure::mmH2O},
         {"MM[H2O]", precise::pressure::mmH2O},
         {"cmH2O", precise::ten* precise::pressure::mmH2O},
+        {"cm_H2O", precise::ten* precise::pressure::mmH2O},
         {"cm[H2O]", precise::ten* precise::pressure::mmH2O},
         {"CM[H2O]", precise::ten* precise::pressure::mmH2O},
         {"mH2O", precise::kilo* precise::pressure::mmH2O},
+        {"m_H2O", precise::kilo* precise::pressure::mmH2O},
         {"m*H2O", precise::kilo* precise::pressure::mmH2O},
         {"m[H2O]", precise::kilo* precise::pressure::mmH2O},
         {"M[H2O]", precise::kilo* precise::pressure::mmH2O},
@@ -1405,7 +1411,7 @@ UNITS_CPP14_CONSTEXPR_OBJECT std::array<
 
 UNITS_CPP14_CONSTEXPR_OBJECT std::array<
     std::pair<const char*, precise_unit>,
-    988>
+    991>
     defined_unit_strings_customary{{
         {"candle", precise::other::candle},
         {"candlepower", precise::other::candle},
@@ -1991,12 +1997,15 @@ UNITS_CPP14_CONSTEXPR_OBJECT std::array<
         {"[PSI]", precise::pressure::psi},
         {"[psi]", precise::pressure::psi},
         {"inHg", precise::pressure::inHg},
+        {"in_Hg", precise::pressure::inHg},
         {"inchHg", precise::pressure::inHg},
         {"ftH2O", precise_unit(12.0, precise::pressure::inH2O)},
         {"footwater", precise_unit(12.0, precise::pressure::inH2O)},
         {"inH2O", precise::pressure::inH2O},
+        {"in_H2O", precise::pressure::inH2O},
         {"inchH2O", precise::pressure::inH2O},
         {"inAq", precise::pressure::inH2O},
+        {"in_Aq", precise::pressure::inH2O},
         {"in[Hg]", precise::pressure::inHg},
         {"in[H2O]", precise::pressure::inH2O},
         {"IN[HG]", precise::pressure::inHg},


### PR DESCRIPTION
handle very short units with spaces a little cleaner,  things like `kg m`
add some checks for existing units

There are a few cases where this is ambiguous in which case the single unit definition is preferred.  