### PR TITLE
fix for #307

### DIFF
--- a/config/cppcheck_suppressions.txt
+++ b/config/cppcheck_suppressions.txt
@@ -1,6 +1,6 @@
 unusedFunction:units/x12_conv.cpp:1024
 unusedFunction:units/r20_conv.cpp:2738
 unusedFunction:units/x12_conv.cpp:1009
-passedByValue:units/units.cpp:223
-passedByValue:units/units.cpp:1155
-passedByValue:units/units.cpp:1172
+passedByValue:units/units.cpp:224
+passedByValue:units/units.cpp:1156
+passedByValue:units/units.cpp:1173

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -442,6 +442,15 @@ TEST(unitStrings, watthours)
     EXPECT_EQ(str, "GWh*m");
 }
 
+TEST(unitStrings, mm)
+{
+    auto speedUnit = unit_from_string("mm/s");
+    EXPECT_EQ(to_string(speedUnit),"mm/s");
+
+    auto accUnit = unit_from_string("mm/s^2");
+    EXPECT_EQ(to_string(accUnit),"mm/s^2");
+}
+
 TEST(unitStrings, customUnits)
 {
     EXPECT_EQ(to_string(precise::generate_custom_unit(762)), "CXUN[762]");
@@ -1492,6 +1501,7 @@ TEST(commoditizedUnits, prefixed)
     EXPECT_EQ(getCommodityName(commu2.commodity()), "info");
     EXPECT_TRUE(commu2.has_same_base(precise::data::byte));
 }
+
 
 TEST(commoditizedUnits, numericalWords)
 {

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -455,7 +455,6 @@ TEST(unitStrings, mm)
 
     accUnit = unit_from_string("km/s^2");
     EXPECT_EQ(to_string(accUnit), "km/s^2");
-
 }
 
 TEST(unitStrings, customUnits)

--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -449,6 +449,13 @@ TEST(unitStrings, mm)
 
     auto accUnit = unit_from_string("mm/s^2");
     EXPECT_EQ(to_string(accUnit), "mm/s^2");
+
+    speedUnit = unit_from_string("km/s");
+    EXPECT_EQ(to_string(speedUnit), "km/s");
+
+    accUnit = unit_from_string("km/s^2");
+    EXPECT_EQ(to_string(accUnit), "km/s^2");
+
 }
 
 TEST(unitStrings, customUnits)

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -166,7 +166,8 @@ using ustr = std::pair<precise_unit, const char*>;
 // units to divide into tests to explore common multiplier units
 static UNITS_CPP14_CONSTEXPR_OBJECT std::array<ustr, 30> testUnits{
     {ustr{precise::s, "s"},
-    ustr{precise::s.pow(2), "s^2"},  //second squared need to come before meter to deal with accelleration units
+     ustr{precise::s.pow(2), "s^2"},  // second squared need to come before
+                                      // meter to deal with accelleration units
      ustr{precise::m, "m"},
      ustr{precise::kg, "kg"},
      ustr{precise::mol, "mol"},

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -166,7 +166,7 @@ using ustr = std::pair<precise_unit, const char*>;
 // units to divide into tests to explore common multiplier units
 static UNITS_CPP14_CONSTEXPR_OBJECT std::array<ustr, 30> testUnits{
     {ustr{precise::s, "s"},
-    ustr{precise::s.pow(2), "s^2"},
+    ustr{precise::s.pow(2), "s^2"},  //second squared need to come before meter to deal with accelleration units
      ustr{precise::m, "m"},
      ustr{precise::kg, "kg"},
      ustr{precise::mol, "mol"},
@@ -199,8 +199,8 @@ static UNITS_CPP14_CONSTEXPR_OBJECT std::array<ustr, 30> testUnits{
 // units to divide into tests to explore common multiplier units which can be
 // multiplied by power
 static UNITS_CPP14_CONSTEXPR_OBJECT std::array<ustr, 6> testPowerUnits{
-    {ustr{precise::m, "m"},
-     ustr{precise::s, "s"},
+    {ustr{precise::s, "s"},
+     ustr{precise::m, "m"},
      ustr{precise::radian, "rad"},
      ustr{precise::km, "km"},
      ustr{precise::ft, "ft"},

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -164,9 +164,10 @@ static const umap base_unit_names = getDefinedBaseUnitNames();
 
 using ustr = std::pair<precise_unit, const char*>;
 // units to divide into tests to explore common multiplier units
-static UNITS_CPP14_CONSTEXPR_OBJECT std::array<ustr, 29> testUnits{
-    {ustr{precise::m, "m"},
-     ustr{precise::s, "s"},
+static UNITS_CPP14_CONSTEXPR_OBJECT std::array<ustr, 30> testUnits{
+    {ustr{precise::s, "s"},
+    ustr{precise::s.pow(2), "s^2"},
+     ustr{precise::m, "m"},
      ustr{precise::kg, "kg"},
      ustr{precise::mol, "mol"},
      ustr{precise::currency, "$"},


### PR DESCRIPTION
Change the order of to_string processing for meters and seconds to ma…ke some units containing combinations of those units work better.

Fix Issue #307.

