### PR TITLE
remove quad definition as a name

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Units"
-copyright = "2019-2023,\nLawrence Livermore National Security, LLC;See the top-level NOTICE for additional details.\nAll rights reserved.\nSPDX-License-Identifier: BSD-3-Clause\n"
+copyright = "2019-2024,\nLawrence Livermore National Security, LLC;See the top-level NOTICE for additional details.\nAll rights reserved.\nSPDX-License-Identifier: BSD-3-Clause\n"
 author = "Philip Top, Ryan Mast"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,9 @@
-sphinx==4.3.0
-sphinx_rtd_theme==1.2.0
-myst-parser==0.18.1
-ipython==8.10.0
-ipykernel==6.21.2
-nbsphinx==0.8.12
-breathe==4.34.0
+sphinx==7.2.6
+sphinx_rtd_theme==2.0.0
+myst-parser==2.0.0
+ipython==8.22.2
+ipykernel==6.29.3
+nbsphinx==0.9.3
+breathe==4.35.0
 sphinx-markdown-tables==0.0.17
 sphinxcontrib-svg2pdfconverter==1.2.2

--- a/units/r20_conv.cpp
+++ b/units/r20_conv.cpp
@@ -2481,7 +2481,7 @@ namespace precise {
         unitD{"N67", "British thermal unit (59 degF)", energy::btu_59},
         unitD{"N68", "British thermal unit (60 degF)", energy::btu_60},
         unitD{"N69", "calorie (20 degC)", energy::cal_20},
-        unitD{"N70", "quad", energy::quad},
+        unitD{ "N70", "quad", {1e15, energy::btu_it} },
         unitD{"N71", "therm (EC)", energy::therm_ec},
         unitD{"N72", "therm (US)", energy::therm_us},
         unitD{

--- a/units/unit_definitions.hpp
+++ b/units/unit_definitions.hpp
@@ -812,7 +812,6 @@ namespace precise {
         constexpr precise_unit btu_it{1055.05585262, J};  // international table
                                                           // btu
         constexpr precise_unit btu_iso{1055.06, J};  // rounded btu_it
-        constexpr precise_unit quad{1e15, btu_it};
         constexpr precise_unit tonc{12000.0, btu_th / h};
 
         constexpr precise_unit therm_us{100000.0, btu_59};

--- a/units/units_conversion_maps.hpp
+++ b/units/units_conversion_maps.hpp
@@ -142,7 +142,7 @@ UNITS_CPP14_CONSTEXPR_OBJECT std::array<std::pair<unit, const char*>, 113>
          {unit_cast(precise::other::ppm), "ppm"},
          {unit_cast(precise::other::ppb), "ppb"}}};
 
-UNITS_CPP14_CONSTEXPR_OBJECT std::array<std::pair<unit, const char*>, 56>
+UNITS_CPP14_CONSTEXPR_OBJECT std::array<std::pair<unit, const char*>, 55>
     defined_unit_names_customary{{
         {in, "in"},
         {unit_cast(precise::in.pow(2)), "in^2"},
@@ -187,7 +187,6 @@ UNITS_CPP14_CONSTEXPR_OBJECT std::array<std::pair<unit, const char*>, 56>
         {unit_cast(precise::pressure::inH2O), "inH2O"},
         {unit_cast(precise::pressure::torr), "torr"},
         {unit_cast(precise::energy::EER), "EER"},
-        {unit_cast(precise::energy::quad), "quad"},
         {gal, "gal"},
         {unit_cast(precise::us::barrel), "bbl"},
         {lb, "lb"},
@@ -2236,7 +2235,7 @@ UNITS_CPP14_CONSTEXPR_OBJECT std::array<
          {"buckingham",
           {1e-26, precise::cgs::statC_charge* precise::cm.pow(2)}},
          {"landauer", {0.0175, precise::energy::eV / precise::data::bit}},
-         {"quad", precise::energy::quad},
+         {"quad", {1e15, precise::energy::btu_it}},
          {"therm", precise::energy::therm_ec},
          {"thm", precise::energy::therm_ec},
          {"therm(EC)", precise::energy::therm_ec},


### PR DESCRIPTION
remove quad as a defined unit since the name interferes with quad precision definition in some compilers