### PR TITLE
Build aarch64 wheels on GHA ARM runners

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
+        platform: [windows-latest, macos-latest, ubuntu-latest, ubuntu-24.04-arm]
         python-version: ["3.10", "3.12"]
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, windows-latest]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Add AArch64 Linux wheels to the build matrix for Python wheels, using GHA ARM runners.

Building wheels works: https://github.com/LLNL/units/actions/runs/12846484166/job/35821712110