### PR TITLE
Remove AnalyzeTemporaryDtors from .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -76,7 +76,6 @@ WarningsAsErrors: "
 
 HeaderFilterRegex: ".*hpp"
 
-AnalyzeTemporaryDtors: false
 CheckOptions:
   - key: cert-dcl59-cpp.HeaderFileExtensions
     value: h,hh,hpp,hxx


### PR DESCRIPTION
Removed the `AnalyzeTemporaryDtors` option from `.clang-tidy`.

It has been deprecated and causing this error when running `clang-tidy 21.1.7`:

```
.../units-src/.clang-tidy:79:1: error: unknown key 'AnalyzeTemporaryDtors'
AnalyzeTemporaryDtors: false
^~~~~~~~~~~~~~~~~~~~~
```