### PR TITLE
Use a user defined name when the multiplier leaves float range

### DIFF
--- a/test/test_unit_strings.cpp
+++ b/test/test_unit_strings.cpp
@@ -1383,6 +1383,42 @@ TEST(stringToUnits, partitionMinimumDefault)
     EXPECT_EQ(prev, minimum_partition_size3);
 }
 
+TEST(userDefinedUnits, multiplierOutsideFloatRange)
+{
+    // Squaring a unit that is already small enough drives the multiplier below
+    // what a float can hold as a normal value, and to_string used to fall
+    // straight through to the numeric form without ever consulting the user
+    // defined names.
+    auto meV = unit_from_string("meV");
+    ASSERT_FALSE(is_error(meV));
+
+    auto meV2 = meV * meV;
+    addUserDefinedUnit("meV^2", meV2);
+    EXPECT_EQ(to_string(meV2), "meV^2");
+
+    // The same on the other side of the range, where the multiplier overflows
+    // a float instead of underflowing it.
+    auto invmeV2 = meV2.inv();
+    addUserDefinedUnit("1/meV^2", invmeV2);
+    EXPECT_EQ(to_string(invmeV2), "1/meV^2");
+
+    auto barn = unit_from_string("barn");
+    ASSERT_FALSE(is_error(barn));
+    auto barn2 = barn * barn;
+    addUserDefinedUnit("barn^2", barn2);
+    EXPECT_EQ(to_string(barn2), "barn^2");
+
+    // A unit whose multiplier is still a normal float keeps working, and one
+    // that was never named still renders numerically.
+    addUserDefinedUnit("myEnergy", meV);
+    EXPECT_EQ(to_string(meV), "myEnergy");
+
+    auto unnamed = barn2 * barn;
+    EXPECT_NE(to_string(unnamed).find('*'), std::string::npos);
+
+    clearUserDefinedUnits();
+}
+
 TEST(userDefinedUnits, definitions)
 {
     precise_unit clucks(19.3, precise::m * precise::A);

--- a/units/units.cpp
+++ b/units/units.cpp
@@ -1173,6 +1173,20 @@ static std::string
 
 static const std::pair<const unit, std::string> nullret{invalid, std::string{}};
 
+/** Look up only the user defined output names, ignoring the built in ones. */
+static std::string findUserDefinedUnitName(unit un)
+{
+    if (allowUserDefinedUnits.load(std::memory_order_acquire)) {
+        if (!user_defined_unit_names.empty()) {
+            auto fndud = user_defined_unit_names.find(un);
+            if (fndud != user_defined_unit_names.end()) {
+                return fndud->second;
+            }
+        }
+    }
+    return std::string{};
+}
+
 static std::pair<unit, std::string> find_unit_pair(unit un)
 {  // cppcheck suppression active
     if (allowUserDefinedUnits.load(std::memory_order_acquire)) {
@@ -1348,6 +1362,16 @@ static std::string
     // deal with situations where the cast unit is not normal but the precise
     // one is
     if (std::fpclassify(llunit.multiplier_f()) != FP_NORMAL) {
+        // A user defined name is stored against the same unit_cast, so it is
+        // still a match here even though the multiplier no longer survives as
+        // a float. Checking before falling back to the numeric form is what
+        // lets a name like "meV^2" be used: squaring a unit that is already
+        // small enough underflows float, so this branch is taken and the
+        // lookup further down is never reached.
+        auto udefName = findUserDefinedUnitName(llunit);
+        if (!udefName.empty()) {
+            return udefName;
+        }
         auto mstring = getMultiplierString(un.multiplier(), true);
         un = precise_unit(un.base_units());
         mstring.push_back('*');


### PR DESCRIPTION
Fixes #466.

It is a bug rather than a missing formatter case, and it is not really about squaring: squaring is just the easiest way to leave the range of a `float`.

`to_string_internal` casts down to a `unit` and bails out early when the resulting float multiplier is not normal:

```cpp
auto llunit = unit_cast(un);
if (std::fpclassify(llunit.multiplier_f()) != FP_NORMAL) {
    ... multiplier string + base units ...
}
auto fnd = find_unit(llunit);
```

The user defined output names live behind `find_unit`, below that return, so a unit whose multiplier leaves float range never reaches them. `meV^2` has a multiplier of 2.57e-44, which underflows float, so `addUserDefinedUnit("meV^2", ...)` had no effect on the output. `1/meV^2` at 3.89e43 overflows it, and `barn^2` at 1e-56 underflows.

That also explains the shape you saw, where a plain user defined unit works and a squared one does not: `meV` alone is 1.60e-22, comfortably a normal float, so it takes the normal path.

The name is stored against the same `unit_cast` that produces the degenerate multiplier, so it is still a match at that point; this just looks for one before falling back to the numeric form. Reproducing your three cases:

```
before                          after
meV^2   2.5669699665355694e-44*J^2   meV^2
1/meV^2 3.89564355265760538e+43/J^2  1/meV^2
barn^2  9.99999999999999927e-57*m^4  barn^2
meV     meV                          meV
```

## Testing

`userDefinedUnits.multiplierOutsideFloatRange` in `test/test_unit_strings.cpp` covers all three, plus two guards: a unit whose multiplier is still a normal float keeps rendering by its user defined name, and one that was never named still renders numerically, so this cannot pass by handing out names too freely.

On `main` it fails on exactly the three reported cases:

```
Which is: "2.5669699665355694e-44*J^2"
Which is: "3.89564355265760538e+43/J^2"
Which is: "9.99999999999999927e-57*m^4"
```

Full `ctest`: 24/24 passed, including the existing `userDefinedUnits` suite.

One limitation worth stating rather than leaving implied. Because `user_defined_unit_names` is keyed on `unit`, two distinct precise units that both collapse to the same degenerate float multiplier and share base units would collide, and the later registration would win. That is a property of the map's key type rather than something this change introduces, and fixing it would mean keying user defined output names on `precise_unit`, which is a larger change than this issue calls for. Happy to look at that separately if you think it is worth doing.
